### PR TITLE
Add reusable MonthSelector component

### DIFF
--- a/budget-tracker-front/src/components/MonthSelector/MonthSelector.js
+++ b/budget-tracker-front/src/components/MonthSelector/MonthSelector.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import styles from './MonthSelector.module.css';
+
+const MonthSelector = ({ label, onJump, variant = 'overlay' }) => {
+  const classNames = [styles['month-selector']];
+  if (variant === 'overlay') classNames.push(styles.overlay);
+  if (variant === 'spaced') classNames.push(styles.spaced);
+
+  return (
+    <div className={classNames.join(' ')}>
+      <button onClick={() => onJump(-1)}>&lt;</button>
+      <span>{label}</span>
+      <button onClick={() => onJump(1)}>&gt;</button>
+    </div>
+  );
+};
+
+export default MonthSelector;

--- a/budget-tracker-front/src/components/MonthSelector/MonthSelector.js
+++ b/budget-tracker-front/src/components/MonthSelector/MonthSelector.js
@@ -1,18 +1,12 @@
 import React from 'react';
 import styles from './MonthSelector.module.css';
 
-const MonthSelector = ({ label, onJump, variant = 'overlay' }) => {
-  const classNames = [styles['month-selector']];
-  if (variant === 'overlay') classNames.push(styles.overlay);
-  if (variant === 'spaced') classNames.push(styles.spaced);
-
-  return (
-    <div className={classNames.join(' ')}>
-      <button onClick={() => onJump(-1)}>&lt;</button>
-      <span>{label}</span>
-      <button onClick={() => onJump(1)}>&gt;</button>
-    </div>
-  );
-};
+const MonthSelector = ({ label, onJump }) => (
+  <div className={styles['month-selector']}>
+    <button onClick={() => onJump(-1)}>&lt;</button>
+    <span>{label}</span>
+    <button onClick={() => onJump(1)}>&gt;</button>
+  </div>
+);
 
 export default MonthSelector;

--- a/budget-tracker-front/src/components/MonthSelector/MonthSelector.module.css
+++ b/budget-tracker-front/src/components/MonthSelector/MonthSelector.module.css
@@ -1,0 +1,38 @@
+.month-selector{
+  display:flex;
+  align-items:center;
+  width:260px;
+  justify-content:space-between;
+  font-size:1.3rem;
+  color:var(--color-white);
+}
+
+.month-selector span{
+  flex:1;
+  text-align:center;
+  white-space:nowrap;
+}
+
+.month-selector button{
+  flex:0 0 32px;
+  background:transparent;
+  border:none;
+  color:var(--color-white);
+  font-size:1.5rem;
+  cursor:pointer;
+  padding:0;
+}
+.month-selector button:hover{opacity:.75;}
+
+.overlay{
+  position:absolute;
+  top:80px;
+  left:54.5%;
+  transform:translateX(-50%);
+  gap:12px;
+  z-index:900;
+}
+
+.spaced{
+  margin:0 auto 24px auto;
+}

--- a/budget-tracker-front/src/components/MonthSelector/MonthSelector.module.css
+++ b/budget-tracker-front/src/components/MonthSelector/MonthSelector.module.css
@@ -5,6 +5,7 @@
   justify-content:space-between;
   font-size:1.3rem;
   color:var(--color-white);
+  margin:0 auto 24px auto;
 }
 
 .month-selector span{
@@ -22,17 +23,6 @@
   cursor:pointer;
   padding:0;
 }
+
 .month-selector button:hover{opacity:.75;}
 
-.overlay{
-  position:absolute;
-  top:80px;
-  left:54.5%;
-  transform:translateX(-50%);
-  gap:12px;
-  z-index:900;
-}
-
-.spaced{
-  margin:0 auto 24px auto;
-}

--- a/budget-tracker-front/src/components/MonthSelector/MonthSelector.module.css
+++ b/budget-tracker-front/src/components/MonthSelector/MonthSelector.module.css
@@ -5,7 +5,7 @@
   justify-content:space-between;
   font-size:1.3rem;
   color:var(--color-white);
-  margin:0 auto 24px auto;
+  margin:0 auto 15px auto;
 }
 
 .month-selector span{

--- a/budget-tracker-front/src/pages/Expenses/ExpensesPage/Expenses.js
+++ b/budget-tracker-front/src/pages/Expenses/ExpensesPage/Expenses.js
@@ -34,11 +34,7 @@ const Expenses = () => {
   return (
     <div className={styles.container}>
       {/* селектор місяця */}
-      <MonthSelector
-        label={monthLabel}
-        onJump={changeMonth}
-        variant="overlay"
-      />
+      <MonthSelector label={monthLabel} onJump={changeMonth} />
 
       <div className={styles.content}>
         <ExpensesTable startDate={startOfMonth} endDate={endOfMonth} />

--- a/budget-tracker-front/src/pages/Expenses/ExpensesPage/Expenses.js
+++ b/budget-tracker-front/src/pages/Expenses/ExpensesPage/Expenses.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import ExpensesTable from '../ExpensesTable/ExpensesTable';
+import MonthSelector from '../../../components/MonthSelector/MonthSelector';
 import styles from './Expenses.module.css';
 
 /* YYYY-MM-DD */
@@ -33,11 +34,11 @@ const Expenses = () => {
   return (
     <div className={styles.container}>
       {/* селектор місяця */}
-      <div className={styles['month-selector']}>
-        <button onClick={() => changeMonth(-1)}>&lt;</button>
-        <span>{monthLabel}</span>
-        <button onClick={() => changeMonth(1)}>&gt;</button>
-      </div>
+      <MonthSelector
+        label={monthLabel}
+        onJump={changeMonth}
+        variant="overlay"
+      />
 
       <div className={styles.content}>
         <ExpensesTable startDate={startOfMonth} endDate={endOfMonth} />

--- a/budget-tracker-front/src/pages/Expenses/ExpensesPage/Expenses.module.css
+++ b/budget-tracker-front/src/pages/Expenses/ExpensesPage/Expenses.module.css
@@ -27,40 +27,4 @@ ExpensesTable{
     width: 85%;
 }
 
-/* селектор месяца */
-.month-selector{
-  position:absolute;
-  top:80px;             /* как было */
-  left:54.5%;
-  transform:translateX(-50%);
-  display:flex;
-  align-items:center;
-
-  width:260px;          /* ← фиксированная ширина контейнера */
-  justify-content:space-between;
-
-  gap:12px;
-  font-size:1.3rem;
-  color:var(--color-white);
-  z-index:900;
-}
-
-/* название месяца по центру */
-.month-selector span{
-  flex:1;
-  text-align:center;
-  white-space:nowrap;
-}
-
-/* стрелки — фиксированная ширина, без фона */
-.month-selector button{
-  flex:0 0 32px;        /* ← стрелки всегда занимают 32 px */
-  background:transparent;
-  border:none;
-  color:var(--color-white);
-  font-size:1.5rem;
-  cursor:pointer;
-  padding:0;
-}
-.month-selector button:hover{ opacity:.75; }
 

--- a/budget-tracker-front/src/pages/Incomes/IncomesPage/Incomes.js
+++ b/budget-tracker-front/src/pages/Incomes/IncomesPage/Incomes.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import IncomesTable from '../IncomesTable/IncomesTable';
+import MonthSelector from '../../../components/MonthSelector/MonthSelector';
 import styles from './Incomes.module.css';
 
 const Incomes = () => {
@@ -21,11 +22,7 @@ const Incomes = () => {
   return (
     <div className={styles.container}>
       {/* селектор місяця під шапкою */}
-      <div className={styles['month-selector']}>
-        <button onClick={()=>jump(-1)}>&lt;</button>
-        <span>{label}</span>
-        <button onClick={()=>jump(1)}>&gt;</button>
-      </div>
+      <MonthSelector label={label} onJump={jump} variant="overlay" />
 
       <div className={styles.content}>
         <IncomesTable startDate={start} endDate={end} />

--- a/budget-tracker-front/src/pages/Incomes/IncomesPage/Incomes.js
+++ b/budget-tracker-front/src/pages/Incomes/IncomesPage/Incomes.js
@@ -22,7 +22,7 @@ const Incomes = () => {
   return (
     <div className={styles.container}>
       {/* селектор місяця під шапкою */}
-      <MonthSelector label={label} onJump={jump} variant="overlay" />
+      <MonthSelector label={label} onJump={jump} />
 
       <div className={styles.content}>
         <IncomesTable startDate={start} endDate={end} />

--- a/budget-tracker-front/src/pages/Incomes/IncomesPage/Incomes.module.css
+++ b/budget-tracker-front/src/pages/Incomes/IncomesPage/Incomes.module.css
@@ -13,38 +13,6 @@
   }
 
   /* общий селектор месяца (тот же класс, что у расходов) */
-.month-selector{
-  position:absolute;
-  top:80px;
-  left:54.5%;
-  transform:translateX(-50%);
-  display:flex;
-  align-items:center;
-  width:260px;
-  justify-content:space-between;
-  gap:12px;
-  font-size:1.3rem;
-  color:var(--color-white);
-  z-index:900;
-}
-
-.month-selector span{
-  flex:1;
-  text-align:center;
-  white-space:nowrap;
-}
-
-.month-selector button{
-  flex:0 0 32px;
-  background:transparent;
-  border:none;
-  color:var(--color-white);
-  font-size:1.5rem;
-  cursor:pointer;
-  padding:0;
-}
-
-.month-selector button:hover{opacity:.75;}
   
 /* Стили контейнера и селектора месяца взяты из ExpensesPage */
 .container{

--- a/budget-tracker-front/src/pages/MonthlyReport/MonthlyReport.js
+++ b/budget-tracker-front/src/pages/MonthlyReport/MonthlyReport.js
@@ -106,7 +106,7 @@ const MonthlyReport = () => {
   return (
     <div className={styles.container}>
       {/* селектор місяця */}
-      <MonthSelector label={monthLabel} onJump={jumpMonth} variant="spaced" />
+      <MonthSelector label={monthLabel} onJump={jumpMonth} />
 
       <div className={styles.content}>
         <SummaryCards

--- a/budget-tracker-front/src/pages/MonthlyReport/MonthlyReport.js
+++ b/budget-tracker-front/src/pages/MonthlyReport/MonthlyReport.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react";
 import API_ENDPOINTS from "../../config/apiConfig";
+import MonthSelector from "../../components/MonthSelector/MonthSelector";
 
 import SummaryCards from "./components/SummaryCards/SummaryCards";
 import PieChart from "./components/PieChart/PieChart";
@@ -105,11 +106,7 @@ const MonthlyReport = () => {
   return (
     <div className={styles.container}>
       {/* селектор місяця */}
-      <div className={styles["month-selector"]}>
-        <button onClick={() => jumpMonth(-1)}>&lt;</button>
-        <span>{monthLabel}</span>
-        <button onClick={() => jumpMonth(1)}>&gt;</button>
-      </div>
+      <MonthSelector label={monthLabel} onJump={jumpMonth} variant="spaced" />
 
       <div className={styles.content}>
         <SummaryCards

--- a/budget-tracker-front/src/pages/MonthlyReport/MonthlyReport.module.css
+++ b/budget-tracker-front/src/pages/MonthlyReport/MonthlyReport.module.css
@@ -35,22 +35,6 @@
 }
 .loading,.error{ text-align:center; }
 
-.month-selector{
-  display:flex; align-items:center;
-  width:260px;                     /* фіксована ширина — тепер не «роздуває» сторінку */
-  justify-content:space-between;
-  margin:0 auto 24px auto;         /* 24 px відступ униз → більше не перекриває картки */
-  font-size:1.3rem; color:#fff;
-}
-.month-selector span{
-  flex:1; text-align:center; white-space:nowrap;
-}
-.month-selector button{
-  flex:0 0 32px;
-  background:transparent; border:none; color:#fff;
-  font-size:1.5rem; cursor:pointer; padding:0;
-}
-.month-selector button:hover{ opacity:.75; }
 
 /* центруємо title у всіх картках звіту */
 .pie-card h4,

--- a/budget-tracker-front/src/pages/Transfers/TransfersPage/TransfersPage.js
+++ b/budget-tracker-front/src/pages/Transfers/TransfersPage/TransfersPage.js
@@ -22,7 +22,7 @@ const TransfersPage = () => {
 
   return (
     <div className={styles.container}>
-      <MonthSelector label={label} onJump={jump} variant="overlay" />
+      <MonthSelector label={label} onJump={jump} />
 
       <div className={styles.content}>
         <TransfersTable startDate={start} endDate={end} />

--- a/budget-tracker-front/src/pages/Transfers/TransfersPage/TransfersPage.js
+++ b/budget-tracker-front/src/pages/Transfers/TransfersPage/TransfersPage.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import TransfersTable from '../TransfersTable/TransfersTable';
+import MonthSelector from '../../../components/MonthSelector/MonthSelector';
 import styles from './TransfersPage.module.css';
 
 const TransfersPage = () => {
@@ -21,11 +22,7 @@ const TransfersPage = () => {
 
   return (
     <div className={styles.container}>
-      <div className={styles['month-selector']}>
-        <button onClick={()=>jump(-1)}>&lt;</button>
-        <span>{label}</span>
-        <button onClick={()=>jump(1)}>&gt;</button>
-      </div>
+      <MonthSelector label={label} onJump={jump} variant="overlay" />
 
       <div className={styles.content}>
         <TransfersTable startDate={start} endDate={end} />

--- a/budget-tracker-front/src/pages/Transfers/TransfersPage/TransfersPage.module.css
+++ b/budget-tracker-front/src/pages/Transfers/TransfersPage/TransfersPage.module.css
@@ -15,38 +15,6 @@
     align-items:center;
 }
 
-.month-selector{
-  position:absolute;
-  top:80px;
-  left:54.5%;
-  transform:translateX(-50%);
-  display:flex;
-  align-items:center;
-  width:260px;
-  justify-content:space-between;
-  gap:12px;
-  font-size:1.3rem;
-  color:var(--color-white);
-  z-index:900;
-}
-
-.month-selector span{
-  flex:1;
-  text-align:center;
-  white-space:nowrap;
-}
-
-.month-selector button{
-  flex:0 0 32px;
-  background:transparent;
-  border:none;
-  color:var(--color-white);
-  font-size:1.5rem;
-  cursor:pointer;
-  padding:0;
-}
-
-.month-selector button:hover{opacity:.75;}
 
 .transfers-table-container{ overflow-x:auto; margin:20px 0; width:100%; }
 .transfers-table{


### PR DESCRIPTION
## Summary
- extract month selector markup/styles into a reusable `MonthSelector` component
- replace duplicated month selector UI in pages with new component
- remove old page-specific CSS

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685acb372b648330955429a5c0529555