### PR TITLE
Improve DataTable appearance

### DIFF
--- a/budget-tracker-front/src/components/DataTable/DataTable.js
+++ b/budget-tracker-front/src/components/DataTable/DataTable.js
@@ -35,6 +35,9 @@ const DataTable = ({ columns, rows, onDelete, deletingId }) => {
               <th
                 key={col.key}
                 onClick={() => col.sortable && handleSort(col.key)}
+                className={
+                  sortConfig.key === col.key ? styles["sorted"] : undefined
+                }
               >
                 {col.label}
                 {col.sortable && sortConfig.key === col.key

--- a/budget-tracker-front/src/components/DataTable/DataTable.module.css
+++ b/budget-tracker-front/src/components/DataTable/DataTable.module.css
@@ -1,7 +1,8 @@
+
 .data-table-container {
   overflow-x: auto;
-  margin: 10px auto; /* center tables */
-  width: 100%; /* leave space on sides */
+  margin: 20px 0; /* give tables a bit more breathing room */
+  width: 100%;
 }
 
 .data-table {
@@ -9,6 +10,9 @@
   border-collapse: collapse;
   color: var(--color-light);
   background-color: var(--color-gray-dark);
+  border-radius: var(--border-radius-medium);
+  box-shadow: var(--shadow-medium);
+  overflow: hidden; /* keep rounded corners */
 }
 
 .data-table th,
@@ -24,9 +28,15 @@
   cursor: pointer;
   -webkit-user-select: none;
   user-select: none;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
 }
 
 .data-table th:hover {
+  background-color: var(--color-purple-dark);
+}
+
+.sorted {
   background-color: var(--color-purple-dark);
 }
 
@@ -36,15 +46,21 @@
 
 .data-table tr:hover {
   background-color: var(--color-purple-dark);
+  transition: background-color 0.2s ease;
 }
 
 .del-btn {
   background: var(--danger-color);
   color: var(--color-white);
   border: none;
-  border-radius: 4px;
+  border-radius: var(--border-radius-small);
   padding: 2px 8px;
   cursor: pointer;
+  transition: filter 0.2s ease;
+}
+
+.del-btn:hover:not(:disabled) {
+  filter: brightness(1.1);
 }
 
 .del-btn:disabled {


### PR DESCRIPTION
## Summary
- restyle `DataTable` with rounded corners and shadow
- highlight active sort column and hover row transition
- tweak delete button style

## Testing
- `npm install`
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685bd42babbc8330b03d960ae8a4f7c1