### PR TITLE
Show plan transactions and allow editing

### DIFF
--- a/budget-tracker-front/src/components/DataTable/DataTable.js
+++ b/budget-tracker-front/src/components/DataTable/DataTable.js
@@ -1,7 +1,14 @@
 import { useState, useMemo } from "react";
 import styles from "./DataTable.module.css";
 
-const DataTable = ({ columns, rows, onDelete, deletingId }) => {
+const DataTable = ({
+  columns,
+  rows,
+  onDelete,
+  deletingId,
+  onEdit,
+  editingId,
+}) => {
   const [sortConfig, setSortConfig] = useState({ key: null, direction: "asc" });
 
   const handleSort = (key) => {
@@ -47,7 +54,7 @@ const DataTable = ({ columns, rows, onDelete, deletingId }) => {
                   : ""}
               </th>
             ))}
-            {onDelete && <th></th>}
+            {(onDelete || onEdit) && <th></th>}
           </tr>
         </thead>
         <tbody>
@@ -58,15 +65,26 @@ const DataTable = ({ columns, rows, onDelete, deletingId }) => {
                   {col.render ? col.render(row[col.key], row) : row[col.key]}
                 </td>
               ))}
-              {onDelete && (
+              {(onEdit || onDelete) && (
                 <td>
-                  <button
-                    className={styles["del-btn"]}
-                    disabled={deletingId === row.id}
-                    onClick={() => onDelete(row.id)}
-                  >
-                    {deletingId === row.id ? "…" : "✕"}
-                  </button>
+                  {onEdit && (
+                    <button
+                      className={styles["edit-btn"]}
+                      disabled={editingId === row.id}
+                      onClick={() => onEdit(row)}
+                    >
+                      {editingId === row.id ? "…" : "✎"}
+                    </button>
+                  )}
+                  {onDelete && (
+                    <button
+                      className={styles["del-btn"]}
+                      disabled={deletingId === row.id}
+                      onClick={() => onDelete(row.id)}
+                    >
+                      {deletingId === row.id ? "…" : "✕"}
+                    </button>
+                  )}
                 </td>
               )}
             </tr>

--- a/budget-tracker-front/src/components/DataTable/DataTable.module.css
+++ b/budget-tracker-front/src/components/DataTable/DataTable.module.css
@@ -67,3 +67,23 @@
   opacity: 0.6;
   cursor: default;
 }
+
+.edit-btn {
+  background: #1e88e5;
+  color: var(--color-white);
+  border: none;
+  border-radius: var(--border-radius-small);
+  padding: 2px 8px;
+  cursor: pointer;
+  margin-right: 6px;
+  transition: filter 0.2s ease;
+}
+
+.edit-btn:hover:not(:disabled) {
+  filter: brightness(1.1);
+}
+
+.edit-btn:disabled {
+  opacity: 0.6;
+  cursor: default;
+}

--- a/budget-tracker-front/src/pages/BudgetPlan/BudgetPlanPage/BudgetPlanPage.js
+++ b/budget-tracker-front/src/pages/BudgetPlan/BudgetPlanPage/BudgetPlanPage.js
@@ -4,6 +4,7 @@ import API_ENDPOINTS from "../../../config/apiConfig";
 
 import PlanDetails from "../PlanDetails/PlanDetails";
 import PlanItemsTable from "../PlanItemsTable/PlanItemsTable";
+import PlanTransactionsTable from "../PlanTransactionsTable";
 import CreatePlanModal from "../CreatePlanModal/CreatePlanModal";
 import EditPlanModal from "../EditPlanModal/EditPlanModal";
 
@@ -106,6 +107,7 @@ useEffect(() => {
         <div className={styles.content}>
           <PlanDetails plan={selectedPlan} />
           <PlanItemsTable items={planItems} />
+          <PlanTransactionsTable planId={selectedPlan.id} />
           <div className={styles["plan-actions"]}>
             <button
               className={styles["edit-btn"]}

--- a/budget-tracker-front/src/pages/BudgetPlan/PlanTransactionsTable/PlanTransactionsTable.js
+++ b/budget-tracker-front/src/pages/BudgetPlan/PlanTransactionsTable/PlanTransactionsTable.js
@@ -1,0 +1,86 @@
+import { useState, useEffect } from 'react';
+import DataTable from '../../../components/DataTable/DataTable';
+import ExpenseModal from '../../../components/Modals/ExpenseModal/ExpenseModal';
+import IncomeModal from '../../../components/Modals/IncomeModal/IncomeModal';
+import TransferModal from '../../../components/Modals/TransferModal/TransferModal';
+import API_ENDPOINTS from '../../../config/apiConfig';
+
+const PlanTransactionsTable = ({ planId }) => {
+  const [transactions, setTransactions] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [busyId, setBusyId] = useState(null);
+  const [editTx, setEditTx] = useState(null);
+
+  useEffect(() => {
+    if (!planId) return;
+    const controller = new AbortController();
+    (async () => {
+      setLoading(true); setError(null);
+      try {
+        const res = await fetch(API_ENDPOINTS.transactionsByPlan(planId), { signal: controller.signal });
+        if (!res.ok) throw new Error('Помилка завантаження');
+        const data = await res.json();
+        setTransactions(data.transactions || data);
+      } catch (e) { if (e.name !== 'AbortError') setError(e.message); }
+      finally { setLoading(false); }
+    })();
+    return () => controller.abort();
+  }, [planId]);
+
+  const handleDelete = async (id) => {
+    if (!window.confirm('Видалити транзакцію?')) return;
+    try {
+      setBusyId(id);
+      const r = await fetch(API_ENDPOINTS.deleteTransaction(id), { method: 'DELETE' });
+      if (!r.ok) throw new Error('Помилка видалення');
+      setTransactions(t => t.filter(tx => tx.id !== id));
+    } catch (e) { alert(e.message); }
+    finally { setBusyId(null); }
+  };
+
+  const handleEdit = (tx) => setEditTx(tx);
+
+  const handleSaved = (tx) => {
+    setTransactions(t => t.map(x => (x.id === tx.id ? { ...x, ...tx } : x)));
+    setEditTx(null);
+  };
+
+  if (loading) return <p>Завантаження...</p>;
+  if (error) return <p className="error">Помилка: {error}</p>;
+
+  const columns = [
+    { key: 'title', label: 'Назва', sortable: true },
+    { key: 'amount', label: 'Сума', sortable: true, render: (v,r) => `${r.currencySymbol} ${Number(v).toFixed(2)}` },
+    { key: 'categoryTitle', label: 'Категорія', sortable: true },
+    { key: 'accountTitle', label: 'Рахунок', sortable: true },
+    { key: 'accountFromTitle', label: 'З рахунку', sortable: true },
+    { key: 'accountToTitle', label: 'На рахунок', sortable: true },
+    { key: 'date', label: 'Дата', sortable: true, render: v => new Date(v).toLocaleDateString() },
+    { key: 'description', label: 'Опис', render: v => v || '-' },
+  ];
+
+  const renderModal = () => {
+    if (!editTx) return null;
+    if (editTx.accountFromTitle && editTx.accountToTitle)
+      return <TransferModal isOpen={true} onClose={() => setEditTx(null)} transaction={editTx} onSaved={handleSaved} />;
+    if (editTx.accountFromTitle || editTx.accountFrom)
+      return <ExpenseModal isOpen={true} onClose={() => setEditTx(null)} transaction={editTx} onSaved={handleSaved} />;
+    return <IncomeModal isOpen={true} onClose={() => setEditTx(null)} transaction={editTx} onSaved={handleSaved} />;
+  };
+
+  return (
+    <>
+      <DataTable
+        columns={columns}
+        rows={transactions}
+        onDelete={handleDelete}
+        onEdit={handleEdit}
+        deletingId={busyId}
+      />
+      {renderModal()}
+    </>
+  );
+};
+
+export default PlanTransactionsTable;

--- a/budget-tracker-front/src/pages/BudgetPlan/PlanTransactionsTable/PlanTransactionsTable.js
+++ b/budget-tracker-front/src/pages/BudgetPlan/PlanTransactionsTable/PlanTransactionsTable.js
@@ -51,22 +51,76 @@ const PlanTransactionsTable = ({ planId }) => {
 
   const columns = [
     { key: 'title', label: 'Назва', sortable: true },
-    { key: 'amount', label: 'Сума', sortable: true, render: (v,r) => `${r.currencySymbol} ${Number(v).toFixed(2)}` },
-    { key: 'categoryTitle', label: 'Категорія', sortable: true },
-    { key: 'accountTitle', label: 'Рахунок', sortable: true },
-    { key: 'accountFromTitle', label: 'З рахунку', sortable: true },
-    { key: 'accountToTitle', label: 'На рахунок', sortable: true },
-    { key: 'date', label: 'Дата', sortable: true, render: v => new Date(v).toLocaleDateString() },
-    { key: 'description', label: 'Опис', render: v => v || '-' },
+    {
+      key: 'amount',
+      label: 'Сума',
+      sortable: true,
+      render: (v, r) => `${r.currencySymbol} ${Number(v).toFixed(2)}`,
+    },
+    {
+      key: 'categoryTitle',
+      label: 'Категорія',
+      sortable: true,
+      render: (v) => v || '-',
+    },
+    {
+      key: 'accountTitle',
+      label: 'Рахунок',
+      sortable: true,
+      render: (v, r) => v || r.accountFromTitle || r.accountToTitle || '-',
+    },
+    {
+      key: 'accountFromTitle',
+      label: 'З рахунку',
+      sortable: true,
+      render: (v) => v || '-',
+    },
+    {
+      key: 'accountToTitle',
+      label: 'На рахунок',
+      sortable: true,
+      render: (v) => v || '-',
+    },
+    {
+      key: 'date',
+      label: 'Дата',
+      sortable: true,
+      render: (v) => new Date(v).toLocaleDateString(),
+    },
+    { key: 'description', label: 'Опис', render: (v) => v || '-' },
   ];
 
   const renderModal = () => {
     if (!editTx) return null;
-    if (editTx.accountFromTitle && editTx.accountToTitle)
-      return <TransferModal isOpen={true} onClose={() => setEditTx(null)} transaction={editTx} onSaved={handleSaved} />;
-    if (editTx.accountFromTitle || editTx.accountFrom)
-      return <ExpenseModal isOpen={true} onClose={() => setEditTx(null)} transaction={editTx} onSaved={handleSaved} />;
-    return <IncomeModal isOpen={true} onClose={() => setEditTx(null)} transaction={editTx} onSaved={handleSaved} />;
+    // determine type based on available account fields
+    if (editTx.accountFromTitle && editTx.accountToTitle) {
+      return (
+        <TransferModal
+          isOpen={true}
+          onClose={() => setEditTx(null)}
+          transaction={editTx}
+          onSaved={handleSaved}
+        />
+      );
+    }
+    if (editTx.accountFromTitle) {
+      return (
+        <ExpenseModal
+          isOpen={true}
+          onClose={() => setEditTx(null)}
+          transaction={editTx}
+          onSaved={handleSaved}
+        />
+      );
+    }
+    return (
+      <IncomeModal
+        isOpen={true}
+        onClose={() => setEditTx(null)}
+        transaction={editTx}
+        onSaved={handleSaved}
+      />
+    );
   };
 
   return (

--- a/budget-tracker-front/src/pages/BudgetPlan/PlanTransactionsTable/index.js
+++ b/budget-tracker-front/src/pages/BudgetPlan/PlanTransactionsTable/index.js
@@ -1,0 +1,1 @@
+export { default } from './PlanTransactionsTable';

--- a/budget-tracker-front/src/pages/Expenses/ExpensesTable/ExpensesTable.js
+++ b/budget-tracker-front/src/pages/Expenses/ExpensesTable/ExpensesTable.js
@@ -1,12 +1,14 @@
 import { useState, useEffect } from 'react';
 import { API_ENDPOINTS } from '../../../config/apiConfig';
 import DataTable from '../../../components/DataTable/DataTable';
+import ExpenseModal from '../../../components/Modals/ExpenseModal/ExpenseModal';
 
 const ExpensesTable = ({ month, year }) => {
   const [transactions, setTransactions] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [busyId, setBusyId] = useState(null);
+  const [editTx, setEditTx] = useState(null);
 
   useEffect(() => {
     const fetchData = async () => {
@@ -41,6 +43,13 @@ const ExpensesTable = ({ month, year }) => {
     }
   };
 
+  const handleEdit = (tx) => setEditTx(tx);
+
+  const handleSaved = (tx) => {
+    setTransactions((prev) => prev.map((t) => (t.id === tx.id ? { ...t, ...tx } : t)));
+    setEditTx(null);
+  };
+
   if (loading) return <p>Завантаження...</p>;
   if (error) return <p className="error">Помилка: {error}</p>;
 
@@ -54,12 +63,23 @@ const ExpensesTable = ({ month, year }) => {
   ];
 
   return (
-    <DataTable
-      columns={columns}
-      rows={transactions}
-      onDelete={handleDelete}
-      deletingId={busyId}
-    />
+    <>
+      <DataTable
+        columns={columns}
+        rows={transactions}
+        onDelete={handleDelete}
+        onEdit={handleEdit}
+        deletingId={busyId}
+      />
+      {editTx && (
+        <ExpenseModal
+          isOpen={!!editTx}
+          onClose={() => setEditTx(null)}
+          transaction={editTx}
+          onSaved={handleSaved}
+        />
+      )}
+    </>
   );
 };
 

--- a/budget-tracker-front/src/pages/Incomes/IncomesTable/IncomesTable.js
+++ b/budget-tracker-front/src/pages/Incomes/IncomesTable/IncomesTable.js
@@ -1,12 +1,14 @@
 import { useState, useEffect } from 'react';
 import API_ENDPOINTS from '../../../config/apiConfig';
 import DataTable from '../../../components/DataTable/DataTable';
+import IncomeModal from '../../../components/Modals/IncomeModal/IncomeModal';
 
 const IncomesTable = ({ month, year }) => {
   const [transactions, setTransactions] = useState([]);
   const [loading,      setLoading]      = useState(true);
   const [error,        setError]        = useState(null);
   const [busyId,       setBusyId]       = useState(null);
+  const [editTx,       setEditTx]       = useState(null);
 
   useEffect(()=>{
     const fetchData = async ()=>{
@@ -36,6 +38,13 @@ const IncomesTable = ({ month, year }) => {
     finally{ setBusyId(null); }
   };
 
+  const handleEdit = (tx) => setEditTx(tx);
+
+  const handleSaved = (tx) => {
+    setTransactions(p => p.map(t => (t.id === tx.id ? { ...t, ...tx } : t)));
+    setEditTx(null);
+  };
+
   if(loading) return <p>Завантаження...</p>;
   if(error)   return <p className="error">Помилка: {error}</p>;
 
@@ -49,7 +58,23 @@ const IncomesTable = ({ month, year }) => {
   ];
 
   return (
-    <DataTable columns={columns} rows={rows} onDelete={del} deletingId={busyId} />
+    <>
+      <DataTable
+        columns={columns}
+        rows={rows}
+        onDelete={del}
+        onEdit={handleEdit}
+        deletingId={busyId}
+      />
+      {editTx && (
+        <IncomeModal
+          isOpen={!!editTx}
+          onClose={() => setEditTx(null)}
+          transaction={editTx}
+          onSaved={handleSaved}
+        />
+      )}
+    </>
   );
 };
 

--- a/budget-tracker-front/src/pages/Transfers/TransfersTable/TransfersTable.js
+++ b/budget-tracker-front/src/pages/Transfers/TransfersTable/TransfersTable.js
@@ -1,12 +1,14 @@
 import { useState, useEffect } from 'react';
 import API_ENDPOINTS from '../../../config/apiConfig';
 import DataTable from '../../../components/DataTable/DataTable';
+import TransferModal from '../../../components/Modals/TransferModal/TransferModal';
 
 const TransfersTable = ({ month, year }) => {
   const [rows, setRows] = useState([]);
   const [loading, setLoad] = useState(true);
   const [error, setErr] = useState(null);
   const [busyId, setBusy] = useState(null);
+  const [editTx, setEditTx] = useState(null);
 
   useEffect(() => {
     const load = async () => {
@@ -34,6 +36,13 @@ const TransfersTable = ({ month, year }) => {
     finally { setBusy(null); }
   };
 
+  const handleEdit = (tx) => setEditTx(tx);
+
+  const handleSaved = (tx) => {
+    setRows(p => p.map(x => (x.id === tx.id ? { ...x, ...tx } : x)));
+    setEditTx(null);
+  };
+
   if (loading) return <p>Завантаження...</p>;
   if (error)   return <p className="error">Помилка: {error}</p>;
 
@@ -46,7 +55,25 @@ const TransfersTable = ({ month, year }) => {
     { key: 'description',      label: 'Опис',                        render: v => v || '-' },
   ];
 
-  return <DataTable columns={columns} rows={rows} onDelete={del} deletingId={busyId} />;
+  return (
+    <>
+      <DataTable
+        columns={columns}
+        rows={rows}
+        onDelete={del}
+        onEdit={handleEdit}
+        deletingId={busyId}
+      />
+      {editTx && (
+        <TransferModal
+          isOpen={!!editTx}
+          onClose={() => setEditTx(null)}
+          transaction={editTx}
+          onSaved={handleSaved}
+        />
+      )}
+    </>
+  );
 };
 
 export default TransfersTable;


### PR DESCRIPTION
## Summary
- support edit buttons in `DataTable`
- extend expense, income and transfer modals to edit transactions
- add edit functionality in all transaction tables
- show transactions table on budget plan page

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686c1d2f34a48330bc2aa75e4639b192