### PR TITLE
Add edit feature to transactions

### DIFF
--- a/budget-tracker-front/src/components/DataTable/DataTable.js
+++ b/budget-tracker-front/src/components/DataTable/DataTable.js
@@ -1,7 +1,7 @@
 import { useState, useMemo } from "react";
 import styles from "./DataTable.module.css";
 
-const DataTable = ({ columns, rows, onDelete, deletingId }) => {
+const DataTable = ({ columns, rows, onDelete, deletingId, onEdit }) => {
   const [sortConfig, setSortConfig] = useState({ key: null, direction: "asc" });
 
   const handleSort = (key) => {
@@ -47,6 +47,7 @@ const DataTable = ({ columns, rows, onDelete, deletingId }) => {
                   : ""}
               </th>
             ))}
+            {onEdit && <th></th>}
             {onDelete && <th></th>}
           </tr>
         </thead>
@@ -58,6 +59,16 @@ const DataTable = ({ columns, rows, onDelete, deletingId }) => {
                   {col.render ? col.render(row[col.key], row) : row[col.key]}
                 </td>
               ))}
+              {onEdit && (
+                <td>
+                  <button
+                    className={styles["edit-btn"]}
+                    onClick={() => onEdit(row.id)}
+                  >
+                    ✎
+                  </button>
+                </td>
+              )}
               {onDelete && (
                 <td>
                   <button

--- a/budget-tracker-front/src/components/DataTable/DataTable.module.css
+++ b/budget-tracker-front/src/components/DataTable/DataTable.module.css
@@ -59,7 +59,22 @@
   transition: filter 0.2s ease;
 }
 
+.edit-btn {
+  background: #1e88e5;
+  color: var(--color-white);
+  border: none;
+  border-radius: var(--border-radius-small);
+  padding: 2px 8px;
+  cursor: pointer;
+  margin-right: 4px;
+  transition: filter 0.2s ease;
+}
+
 .del-btn:hover:not(:disabled) {
+  filter: brightness(1.1);
+}
+
+.edit-btn:hover:not(:disabled) {
   filter: brightness(1.1);
 }
 

--- a/budget-tracker-front/src/pages/BudgetPlan/EditPlanModal/EditPlanModal.js
+++ b/budget-tracker-front/src/pages/BudgetPlan/EditPlanModal/EditPlanModal.js
@@ -25,21 +25,58 @@ const EditPlanModal = ({ isOpen, onClose, plan, items, onSaved }) => {
 
   useEffect(() => {
     if (!isOpen || !plan) return;
+    let ignore = false;
     setTitle(plan.title);
     setStartDate(plan.startDate.substring(0, 10));
     setEndDate(plan.endDate.substring(0, 10));
     setType(String(plan.type));
     setDesc(plan.description || "");
-    setRows(items.map((i) => ({ ...i, _status: "old" })));
+
     (async () => {
       try {
         const res = await fetch(API_ENDPOINTS.editPlanModal);
         if (!res.ok) throw new Error();
         const data = await res.json();
+        if (ignore) return;
         setAllCats(data.categories);
         setAllCur(data.currencies);
-      } catch {}
+        setRows(
+          items.map((i) => ({
+            id: i.id,
+            budgetPlanId: i.budgetPlanId,
+            categoryId:
+              i.categoryId ??
+              data.categories.find((c) => c.title === i.categoryTitle)?.id ??
+              "",
+            amount: i.amount,
+            currencyId:
+              i.currencyId ??
+              data.currencies.find((c) => c.symbol === i.currencySymbol)?.id ??
+              "",
+            description: i.description ?? "",
+            _status: "old",
+          }))
+        );
+      } catch {
+        if (!ignore) {
+          setRows(
+            items.map((i) => ({
+              id: i.id,
+              budgetPlanId: i.budgetPlanId,
+              categoryId: i.categoryId ?? "",
+              amount: i.amount,
+              currencyId: i.currencyId ?? "",
+              description: i.description ?? "",
+              _status: "old",
+            }))
+          );
+        }
+      }
     })();
+
+    return () => {
+      ignore = true;
+    };
   }, [isOpen, plan, items]);
 
   if (!isOpen) return null;


### PR DESCRIPTION
## Summary
- enable an optional edit button in `DataTable`
- style edit button
- extend Expense, Income and Transfer modals to support editing existing data
- reload tables after saving changes
- integrate edit modals in Expenses/Incomes/Transfers tables

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6879e10ee13883308b2d50de49103f06