### PR TITLE
Add dedicated edit modals

### DIFF
--- a/budget-tracker-front/src/components/Modals/EditExpenseModal/EditExpenseModal.js
+++ b/budget-tracker-front/src/components/Modals/EditExpenseModal/EditExpenseModal.js
@@ -1,0 +1,178 @@
+import { useState, useEffect } from "react";
+import API_ENDPOINTS from "../../../config/apiConfig";
+import styles from "./EditExpenseModal.module.css";
+
+const EditExpenseModal = ({ isOpen, onClose, transaction, onSaved }) => {
+  const [title, setTitle] = useState("");
+  const [amount, setAmount] = useState("");
+  const [currencyId, setCurrencyId] = useState("");
+  const [categoryId, setCategoryId] = useState("");
+  const [accountFrom, setAccountFrom] = useState("");
+  const [budgetPlanId, setBudgetPlanId] = useState("");
+  const [description, setDescription] = useState("");
+  const [date, setDate] = useState("");
+
+  const [currencies, setCurrencies] = useState([]);
+  const [categories, setCategories] = useState([]);
+  const [accounts, setAccounts] = useState([]);
+  const [plans, setPlans] = useState([]);
+
+  const [error, setError] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleEsc = (e) => {
+      if (e.key === "Escape") onClose();
+    };
+
+    const load = async () => {
+      try {
+        const res = await fetch(API_ENDPOINTS.expenseModal);
+        if (!res.ok) throw new Error("\u041F\u043E\u043C\u0438\u043B\u043A\u0430 \u0437\u0430\u0432\u0430\u043D\u0442\u0430\u0436\u0435\u043D\u043D\u044F \u0434\u0430\u043D\u0438\u0445");
+        const data = await res.json();
+        setCurrencies(data.currencies);
+        setCategories(data.categories);
+        setAccounts(data.accounts);
+        setPlans(data.plans);
+      } catch (e) {
+        setError(e.message);
+      }
+    };
+
+    load();
+    if (transaction) {
+      setTitle(transaction.title || "");
+      setAmount(transaction.amount ? String(transaction.amount) : "");
+      setCurrencyId(transaction.currencyId ? String(transaction.currencyId) : "");
+      setCategoryId(transaction.categoryId ? String(transaction.categoryId) : "");
+      setAccountFrom(transaction.accountFrom ? String(transaction.accountFrom) : "");
+      setBudgetPlanId(transaction.budgetPlanId ? String(transaction.budgetPlanId) : "");
+      setDescription(transaction.description || "");
+      setDate(transaction.date || "");
+    }
+    document.addEventListener("keydown", handleEsc);
+    return () => document.removeEventListener("keydown", handleEsc);
+  }, [isOpen, onClose, transaction]);
+
+  const handleSubmit = async () => {
+    if (
+      !title ||
+      !amount ||
+      !currencyId ||
+      !categoryId ||
+      !accountFrom ||
+      !budgetPlanId
+    ) {
+      alert("\u0417\u0430\u043F\u043E\u0432\u043D\u0456\u0442\u044C \u0443\u0441\u0456 \u043F\u043E\u043B\u044F!");
+      return;
+    }
+
+    const payload = {
+      id: transaction.id,
+      title,
+      amount: parseFloat(amount),
+      accountFrom: parseInt(accountFrom),
+      budgetPlanId: parseInt(budgetPlanId),
+      currencyId: parseInt(currencyId),
+      categoryId: parseInt(categoryId),
+      date,
+      description,
+      type: 2,
+    };
+
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(API_ENDPOINTS.updateTransaction, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) throw new Error(`\u0421\u0442\u0430\u0442\u0443\u0441 ${res.status}`);
+      onSaved && onSaved();
+      onClose();
+    } catch (e) {
+      setError(e.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className={styles["modal-overlay"]}>
+      <div className={styles["modal-content"]}>
+        <h3>\u0420\u0435\u0434\u0430\u0433\u0443\u0432\u0430\u0442\u0438 \u0432\u0438\u0442\u0440\u0430\u0442\u0443</h3>
+        {error && <p className={styles.error}>{error}</p>}
+
+        <input
+          type="text"
+          placeholder="\u041D\u0430\u0437\u0432\u0430"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+        />
+
+        <input
+          type="number"
+          placeholder="\u0421\u0443\u043C\u0430"
+          value={amount}
+          onChange={(e) => setAmount(e.target.value)}
+        />
+
+        <select value={currencyId} onChange={(e) => setCurrencyId(e.target.value)}>
+          <option value="">\u041E\u0431\u0435\u0440\u0456\u0442\u044C \u0432\u0430\u043B\u044E\u0442\u0443</option>
+          {currencies.map((c) => (
+            <option key={c.id} value={c.id}>
+              {c.symbol} ({c.name})
+            </option>
+          ))}
+        </select>
+
+        <select value={categoryId} onChange={(e) => setCategoryId(e.target.value)}>
+          <option value="">\u041E\u0431\u0435\u0440\u0456\u0442\u044C \u043A\u0430\u0442\u0435\u0433\u043E\u0440\u0456\u044E</option>
+          {categories.map((cat) => (
+            <option key={cat.id} value={cat.id}>
+              {cat.title}
+            </option>
+          ))}
+        </select>
+
+        <select value={accountFrom} onChange={(e) => setAccountFrom(e.target.value)}>
+          <option value="">\u041E\u0431\u0435\u0440\u0456\u0442\u044C \u0440\u0430\u0445\u0443\u043D\u043E\u043A</option>
+          {accounts.map((acc) => (
+            <option key={acc.id} value={acc.id}>
+              {acc.title}
+            </option>
+          ))}
+        </select>
+
+        <select value={budgetPlanId} onChange={(e) => setBudgetPlanId(e.target.value)}>
+          <option value="">\u041E\u0431\u0435\u0440\u0456\u0442\u044C \u043F\u043B\u0430\u043D</option>
+          {plans.map((pl) => (
+            <option key={pl.id} value={pl.id}>
+              {pl.title}
+            </option>
+          ))}
+        </select>
+
+        <textarea
+          placeholder="\u041E\u043F\u0438\u0441"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+        />
+
+        <button onClick={handleSubmit} disabled={loading} className={styles["submit-button"]}>
+          {loading ? "\u0417\u0431\u0435\u0440\u0435\u0436\u0435\u043D\u043D\u044F..." : "\u0417\u0431\u0435\u0440\u0435\u0433\u0442\u0438"}
+        </button>
+        <button onClick={onClose} className={styles["close-button"]}>
+          \u0412\u0456\u0434\u043C\u0456\u043D\u0438\u0442\u0438
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default EditExpenseModal;

--- a/budget-tracker-front/src/components/Modals/EditExpenseModal/EditExpenseModal.module.css
+++ b/budget-tracker-front/src/components/Modals/EditExpenseModal/EditExpenseModal.module.css
@@ -1,0 +1,121 @@
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  /* Полупрозрачный фон */
+  background: rgba(0, 0, 0, 0);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+
+  /* Анимация появления фона */
+  animation: overlayFadeIn 0.3s forwards ease;
+}
+
+@keyframes overlayFadeIn {
+  to {
+    background: rgba(0, 0, 0, 0.5);
+  }
+}
+
+.modal-content {
+  background-color: var(--color-white);
+  /* Лёгкий градиент для фона окна */
+  background-image: linear-gradient(
+    135deg,
+    var(--color-white) 0%,
+    #f9f9ff 100%
+  );
+  padding: 20px;
+  border-radius: 10px;
+  width: 320px;
+  text-align: left;
+  /* Тень */
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.3);
+
+  /* Стартовое состояние анимации */
+  transform: scale(0.8);
+  opacity: 0;
+
+  /* Анимация появления */
+  animation: contentScaleIn 0.3s forwards ease;
+}
+
+@keyframes contentScaleIn {
+  to {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+.modal-content h3 {
+  margin-top: 0;
+  margin-bottom: 15px;
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: var(--table-bg-color);
+}
+
+/* Общий стиль для ошибок */
+.error {
+  color: var(--alert-color);
+  margin: 0 0 10px 0;
+}
+
+.modal-content input,
+.modal-content textarea {
+  width: 93%;
+  padding: 10px;
+  margin: 8px 0;
+  border: 1px solid var(--color-gray-lightest);
+  border-radius: 6px;
+  font-size: 0.95rem;
+}
+
+.modal-content select {
+  padding: 10px;
+  margin: 8px 0;
+  border: 1px solid var(--color-gray-lightest);
+  border-radius: 6px;
+  font-size: 0.95rem;
+  width: 100%;
+}
+
+.modal-content textarea {
+  resize: vertical; /* Можно растягивать по вертикали */
+}
+
+/* Стили кнопок */
+.modal-content button {
+  padding: 10px 16px;
+  margin: 8px 5px 0 0;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.95rem;
+  transition: background-color 0.3s ease;
+}
+
+.modal-content button:disabled {
+  background-color: var(--color-gray-disabled);
+  cursor: not-allowed;
+}
+
+.submit-button {
+  background-color: var(--positive-color); /* зеленая кнопка */
+  color: var(--color-white);
+}
+.submit-button:hover:not(:disabled) {
+  background-color: var(--positive-color-hover);
+}
+
+.close-button {
+  background-color: var(--alert-color);
+  color: var(--color-white);
+}
+.close-button:hover {
+  background-color: var(--danger-color);
+}

--- a/budget-tracker-front/src/components/Modals/EditIncomeModal/EditIncomeModal.js
+++ b/budget-tracker-front/src/components/Modals/EditIncomeModal/EditIncomeModal.js
@@ -1,0 +1,165 @@
+import { useState, useEffect } from "react";
+import API_ENDPOINTS from "../../../config/apiConfig";
+import styles from "./EditIncomeModal.module.css";
+
+const EditIncomeModal = ({ isOpen, onClose, transaction, onSaved }) => {
+  const [title, setTitle] = useState("");
+  const [amount, setAmount] = useState("");
+  const [currencyId, setCurrencyId] = useState("");
+  const [categoryId, setCategoryId] = useState("");
+  const [accountTo, setAccountTo] = useState("");
+  const [description, setDescription] = useState("");
+  const [date, setDate] = useState("");
+  const [currencies, setCurrencies] = useState([]);
+  const [categories, setCategories] = useState([]);
+  const [accounts, setAccounts] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (e) => {
+      if (e.key === "Escape") {
+        onClose();
+      }
+    };
+
+    const fetchData = async () => {
+      try {
+        const res = await fetch(API_ENDPOINTS.incomeModal);
+        if (!res.ok) throw new Error("\u041F\u043E\u043C\u0438\u043B\u043A\u0430 \u0437\u0430\u0432\u0430\u043D\u0442\u0430\u0436\u0435\u043D\u043D\u044F \u0434\u0430\u043D\u0438\u0445");
+        const data = await res.json();
+        setCurrencies(data.currencies);
+        setCategories(data.categories);
+        setAccounts(data.accounts);
+      } catch (error) {
+        setError(error.message);
+      }
+    };
+
+    fetchData();
+    if (transaction) {
+      setTitle(transaction.title || "");
+      setAmount(transaction.amount ? String(transaction.amount) : "");
+      setCurrencyId(transaction.currencyId ? String(transaction.currencyId) : "");
+      setCategoryId(transaction.categoryId ? String(transaction.categoryId) : "");
+      setAccountTo(transaction.accountTo ? String(transaction.accountTo) : "");
+      setDescription(transaction.description || "");
+      setDate(transaction.date || "");
+    }
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isOpen, onClose, transaction]);
+
+  const handleSubmit = async () => {
+    if (!title || !amount || !currencyId || !categoryId || !accountTo) {
+      alert("\u0417\u0430\u043F\u043E\u0432\u043D\u0456\u0442\u044C \u0432\u0441\u0456 \u043F\u043E\u043B\u044F!");
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    const payload = {
+      id: transaction.id,
+      title,
+      amount: parseFloat(amount),
+      currencyId: parseInt(currencyId),
+      categoryId: parseInt(categoryId),
+      date,
+      accountTo: parseInt(accountTo),
+      description,
+      type: 1,
+    };
+
+    try {
+      const response = await fetch(API_ENDPOINTS.updateTransaction, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+
+      if (!response.ok) {
+        throw new Error("\u041F\u043E\u043C\u0438\u043B\u043A\u0430 \u043F\u0440\u0438 \u043E\u043D\u043E\u0432\u043B\u0435\u043D\u043D\u0456");
+      }
+
+      onSaved && onSaved();
+      onClose();
+    } catch (error) {
+      setError(error.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className={styles["modal-overlay"]}>
+      <div className={styles["modal-content"]}>
+        <h3>\u0420\u0435\u0434\u0430\u0433\u0443\u0432\u0430\u0442\u0438 \u0434\u043E\u0445\u0456\u0434</h3>
+        {error && <p className={styles.error}>{error}</p>}
+
+        <input
+          type="text"
+          placeholder="\u041D\u0430\u0437\u0432\u0430"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+        />
+
+        <input
+          type="number"
+          placeholder="\u0421\u0443\u043C\u0430"
+          value={amount}
+          onChange={(e) => setAmount(e.target.value)}
+        />
+
+        <select value={currencyId} onChange={(e) => setCurrencyId(e.target.value)}>
+          <option value="">\u041E\u0431\u0435\u0440\u0456\u0442\u044C \u0432\u0430\u043B\u044E\u0442\u0443</option>
+          {currencies.map((c) => (
+            <option key={c.id} value={c.id}>
+              {c.symbol} ({c.name})
+            </option>
+          ))}
+        </select>
+
+        <select value={categoryId} onChange={(e) => setCategoryId(e.target.value)}>
+          <option value="">\u041E\u0431\u0435\u0440\u0456\u0442\u044C \u043A\u0430\u0442\u0435\u0433\u043E\u0440\u0456\u044E</option>
+          {categories.map((cat) => (
+            <option key={cat.id} value={cat.id}>
+              {cat.title}
+            </option>
+          ))}
+        </select>
+
+        <select value={accountTo} onChange={(e) => setAccountTo(e.target.value)}>
+          <option value="">\u041E\u0431\u0435\u0440\u0456\u0442\u044C \u0440\u0430\u0445\u0443\u043D\u043E\u043A</option>
+          {accounts.map((acc) => (
+            <option key={acc.id} value={acc.id}>
+              {acc.title}
+            </option>
+          ))}
+        </select>
+
+        <textarea
+          placeholder="\u041E\u043F\u0438\u0441"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+        />
+
+        <button onClick={handleSubmit} disabled={loading} className={styles["submit-button"]}>
+          {loading ? "\u0417\u0431\u0435\u0440\u0435\u0436\u0435\u043D\u043D\u044F..." : "\u0417\u0431\u0435\u0440\u0435\u0433\u0442\u0438"}
+        </button>
+        <button onClick={onClose} className={styles["close-button"]}>
+          \u0421\u043A\u0430\u0441\u0443\u0432\u0430\u0442\u0438
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default EditIncomeModal;

--- a/budget-tracker-front/src/components/Modals/EditIncomeModal/EditIncomeModal.module.css
+++ b/budget-tracker-front/src/components/Modals/EditIncomeModal/EditIncomeModal.module.css
@@ -1,0 +1,121 @@
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  /* Полупрозрачный фон */
+  background: rgba(0, 0, 0, 0);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+
+  /* Анимация появления фона */
+  animation: overlayFadeIn 0.3s forwards ease;
+}
+
+@keyframes overlayFadeIn {
+  to {
+    background: rgba(0, 0, 0, 0.5);
+  }
+}
+
+.modal-content {
+  background-color: var(--color-white);
+  /* Лёгкий градиент для фона окна */
+  background-image: linear-gradient(
+    135deg,
+    var(--color-white) 0%,
+    #f9f9ff 100%
+  );
+  padding: 20px;
+  border-radius: 10px;
+  width: 320px;
+  text-align: left;
+  /* Тень */
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.3);
+
+  /* Стартовое состояние анимации */
+  transform: scale(0.8);
+  opacity: 0;
+
+  /* Анимация появления */
+  animation: contentScaleIn 0.3s forwards ease;
+}
+
+@keyframes contentScaleIn {
+  to {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+.modal-content h3 {
+  margin-top: 0;
+  margin-bottom: 15px;
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: var(--table-bg-color);
+}
+
+/* Общий стиль для ошибок */
+.error {
+  color: var(--alert-color);
+  margin: 0 0 10px 0;
+}
+
+.modal-content input,
+.modal-content textarea {
+  width: 93%;
+  padding: 10px;
+  margin: 8px 0;
+  border: 1px solid var(--color-gray-lightest);
+  border-radius: 6px;
+  font-size: 0.95rem;
+}
+
+.modal-content select {
+  padding: 10px;
+  margin: 8px 0;
+  border: 1px solid var(--color-gray-lightest);
+  border-radius: 6px;
+  font-size: 0.95rem;
+  width: 100%;
+}
+
+.modal-content textarea {
+  resize: vertical; /* Можно растягивать по вертикали */
+}
+
+/* Стили кнопок */
+.modal-content button {
+  padding: 10px 16px;
+  margin: 8px 5px 0 0;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.95rem;
+  transition: background-color 0.3s ease;
+}
+
+.modal-content button:disabled {
+  background-color: var(--color-gray-disabled);
+  cursor: not-allowed;
+}
+
+.submit-button {
+  background-color: var(--positive-color); /* зеленая кнопка */
+  color: var(--color-white);
+}
+.submit-button:hover:not(:disabled) {
+  background-color: var(--positive-color-hover);
+}
+
+.close-button {
+  background-color: var(--alert-color);
+  color: var(--color-white);
+}
+.close-button:hover {
+  background-color: var(--danger-color);
+}

--- a/budget-tracker-front/src/components/Modals/EditTransferModal/EditTransferModal.js
+++ b/budget-tracker-front/src/components/Modals/EditTransferModal/EditTransferModal.js
@@ -1,0 +1,185 @@
+import { useState, useEffect } from "react";
+import API_ENDPOINTS from "../../../config/apiConfig";
+import styles from "./EditTransferModal.module.css";
+
+const EditTransferModal = ({ isOpen, onClose, transaction, onSaved }) => {
+  const [title, setTitle] = useState("");
+  const [amount, setAmount] = useState("");
+  const [currencyId, setCurrencyId] = useState("");
+  const [accountFrom, setAccountFrom] = useState("");
+  const [accountTo, setAccountTo] = useState("");
+  const [description, setDescription] = useState("");
+  const [categoryId, setCategoryId] = useState("");
+  const [date, setDate] = useState("");
+  const [currencies, setCurrencies] = useState([]);
+  const [accounts, setAccounts] = useState([]);
+  const [categories, setCategories] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (e) => {
+      if (e.key === "Escape") {
+        onClose();
+      }
+    };
+
+    const fetchData = async () => {
+      try {
+        const res = await fetch(API_ENDPOINTS.transferModal);
+        if (!res.ok) throw new Error("\u041F\u043E\u043C\u0438\u043B\u043A\u0430 \u0437\u0430\u0432\u0430\u043D\u0442\u0430\u0436\u0435\u043D\u043D\u044F \u0434\u0430\u043D\u0438\u0445");
+        const data = await res.json();
+        setCategories(data.categories);
+        setCurrencies(data.currencies);
+        setAccounts(data.accounts);
+      } catch (error) {
+        setError(error.message);
+      }
+    };
+
+    fetchData();
+    if (transaction) {
+      setTitle(transaction.title || "");
+      setAmount(transaction.amount ? String(transaction.amount) : "");
+      setCurrencyId(transaction.currencyId ? String(transaction.currencyId) : "");
+      setAccountFrom(transaction.accountFrom ? String(transaction.accountFrom) : "");
+      setAccountTo(transaction.accountTo ? String(transaction.accountTo) : "");
+      setCategoryId(transaction.categoryId ? String(transaction.categoryId) : "");
+      setDescription(transaction.description || "");
+      setDate(transaction.date || "");
+    }
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isOpen, onClose, transaction]);
+
+  const handleSubmit = async () => {
+    if (!title || !amount || !currencyId || !accountFrom || !accountTo) {
+      alert("\u0417\u0430\u043F\u043E\u0432\u043D\u0456\u0442\u044C \u0432\u0441\u0456 \u043F\u043E\u043B\u044F!");
+      return;
+    }
+
+    if (accountFrom === accountTo) {
+      alert("\u0420\u0430\u0445\u0443\u043D\u043E\u043A \u0432\u0456\u0434\u043F\u0440\u0430\u0432\u043D\u0438\u043A\u0430 \u0442\u0430 \u043E\u0434\u0435\u0440\u0436\u0443\u0432\u0430\u0447\u0430 \u043D\u0435 \u043C\u043E\u0436\u0443\u0442\u044C \u0441\u043F\u0456\u0432\u043F\u0430\u0434\u0430\u0442\u0438!");
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+    const payload = {
+      id: transaction.id,
+      title,
+      amount: parseFloat(amount),
+      accountFrom: parseInt(accountFrom),
+      accountTo: parseInt(accountTo),
+      currencyId: parseInt(currencyId),
+      categoryId: parseInt(categoryId),
+      date,
+      description,
+      type: 0,
+    };
+
+    if (!payload.categoryId) {
+      alert("\u041E\u0431\u0435\u0440\u0456\u0442\u044C \u043A\u0430\u0442\u0435\u0433\u043E\u0440\u0456\u044E!");
+      return;
+    }
+
+    try {
+      const response = await fetch(API_ENDPOINTS.updateTransaction, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+
+      if (!response.ok) {
+        throw new Error("\u041F\u043E\u043C\u0438\u043B\u043A\u0430 \u043F\u0440\u0438 \u043E\u043D\u043E\u0432\u043B\u0435\u043D\u043D\u0456");
+      }
+
+      onSaved && onSaved();
+      onClose();
+    } catch (error) {
+      setError(error.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className={styles["modal-overlay"]}>
+      <div className={styles["modal-content"]}>
+        <h3>\u0420\u0435\u0434\u0430\u0433\u0443\u0432\u0430\u0442\u0438 \u043F\u0435\u0440\u0435\u043A\u0430\u0437</h3>
+        {error && <p className={styles.error}>{error}</p>}
+
+        <input
+          type="text"
+          placeholder="\u041D\u0430\u0437\u0432\u0430"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+        />
+
+        <input
+          type="number"
+          placeholder="\u0421\u0443\u043C\u0430"
+          value={amount}
+          onChange={(e) => setAmount(e.target.value)}
+        />
+
+        <select value={currencyId} onChange={(e) => setCurrencyId(e.target.value)}>
+          <option value="">\u041E\u0431\u0435\u0440\u0456\u0442\u044C \u0432\u0430\u043B\u044E\u0442\u0443</option>
+          {currencies.map((c) => (
+            <option key={c.id} value={c.id}>
+              {c.symbol} ({c.name})
+            </option>
+          ))}
+        </select>
+
+        <select value={accountFrom} onChange={(e) => setAccountFrom(e.target.value)}>
+          <option value="">\u041E\u0431\u0435\u0440\u0456\u0442\u044C \u0440\u0430\u0445\u0443\u043D\u043E\u043A \u0432\u0456\u0434\u043F\u0440\u0430\u0432\u043D\u0438\u043A\u0430</option>
+          {accounts.map((acc) => (
+            <option key={acc.id} value={acc.id}>
+              {acc.title}
+            </option>
+          ))}
+        </select>
+
+        <select value={accountTo} onChange={(e) => setAccountTo(e.target.value)}>
+          <option value="">\u041E\u0431\u0435\u0440\u0456\u0442\u044C \u0440\u0430\u0445\u0443\u043D\u043E\u043A \u043E\u0434\u0435\u0440\u0436\u0443\u0432\u0430\u0447\u0430</option>
+          {accounts.map((acc) => (
+            <option key={acc.id} value={acc.id}>
+              {acc.title}
+            </option>
+          ))}
+        </select>
+        <select value={categoryId} onChange={(e) => setCategoryId(e.target.value)}>
+          <option value="">\u041E\u0431\u0435\u0440\u0456\u0442\u044C \u043A\u0430\u0442\u0435\u0433\u043E\u0440\u0456\u044E</option>
+          {categories.map((cat) => (
+            <option key={cat.id} value={cat.id}>
+              {cat.title}
+            </option>
+          ))}
+        </select>
+
+        <textarea
+          placeholder="\u041E\u043F\u0438\u0441"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+        />
+
+        <button onClick={handleSubmit} disabled={loading} className={styles["submit-button"]}>
+          {loading ? "\u0417\u0431\u0435\u0440\u0435\u0436\u0435\u043D\u043D\u044F..." : "\u0417\u0431\u0435\u0440\u0435\u0433\u0442\u0438"}
+        </button>
+        <button onClick={onClose} className={styles["close-button"]}>
+          \u0421\u043A\u0430\u0441\u0443\u0432\u0430\u0442\u0438
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default EditTransferModal;

--- a/budget-tracker-front/src/components/Modals/EditTransferModal/EditTransferModal.module.css
+++ b/budget-tracker-front/src/components/Modals/EditTransferModal/EditTransferModal.module.css
@@ -1,0 +1,121 @@
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  /* Полупрозрачный фон */
+  background: rgba(0, 0, 0, 0);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+
+  /* Анимация появления фона */
+  animation: overlayFadeIn 0.3s forwards ease;
+}
+
+@keyframes overlayFadeIn {
+  to {
+    background: rgba(0, 0, 0, 0.5);
+  }
+}
+
+.modal-content {
+  background-color: var(--color-white);
+  /* Лёгкий градиент для фона окна */
+  background-image: linear-gradient(
+    135deg,
+    var(--color-white) 0%,
+    #f9f9ff 100%
+  );
+  padding: 20px;
+  border-radius: 10px;
+  width: 320px;
+  text-align: left;
+  /* Тень */
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.3);
+
+  /* Стартовое состояние анимации */
+  transform: scale(0.8);
+  opacity: 0;
+
+  /* Анимация появления */
+  animation: contentScaleIn 0.3s forwards ease;
+}
+
+@keyframes contentScaleIn {
+  to {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+.modal-content h3 {
+  margin-top: 0;
+  margin-bottom: 15px;
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: var(--table-bg-color);
+}
+
+/* Общий стиль для ошибок */
+.error {
+  color: var(--alert-color);
+  margin: 0 0 10px 0;
+}
+
+.modal-content input,
+.modal-content textarea {
+  width: 93%;
+  padding: 10px;
+  margin: 8px 0;
+  border: 1px solid var(--color-gray-lightest);
+  border-radius: 6px;
+  font-size: 0.95rem;
+}
+
+.modal-content select {
+  padding: 10px;
+  margin: 8px 0;
+  border: 1px solid var(--color-gray-lightest);
+  border-radius: 6px;
+  font-size: 0.95rem;
+  width: 100%;
+}
+
+.modal-content textarea {
+  resize: vertical; /* Можно растягивать по вертикали */
+}
+
+/* Стили кнопок */
+.modal-content button {
+  padding: 10px 16px;
+  margin: 8px 5px 0 0;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.95rem;
+  transition: background-color 0.3s ease;
+}
+
+.modal-content button:disabled {
+  background-color: var(--color-gray-disabled);
+  cursor: not-allowed;
+}
+
+.submit-button {
+  background-color: var(--positive-color); /* зеленая кнопка */
+  color: var(--color-white);
+}
+.submit-button:hover:not(:disabled) {
+  background-color: var(--positive-color-hover);
+}
+
+.close-button {
+  background-color: var(--alert-color);
+  color: var(--color-white);
+}
+.close-button:hover {
+  background-color: var(--danger-color);
+}

--- a/budget-tracker-front/src/pages/Expenses/ExpensesTable/ExpensesTable.js
+++ b/budget-tracker-front/src/pages/Expenses/ExpensesTable/ExpensesTable.js
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef } from 'react';
 import { API_ENDPOINTS } from '../../../config/apiConfig';
 import DataTable from '../../../components/DataTable/DataTable';
-import ExpenseModal from '../../../components/Modals/ExpenseModal/ExpenseModal';
+import EditExpenseModal from '../../../components/Modals/EditExpenseModal/EditExpenseModal';
 
 const ExpensesTable = ({ month, year }) => {
   const [transactions, setTransactions] = useState([]);
@@ -79,7 +79,7 @@ const ExpensesTable = ({ month, year }) => {
         deletingId={busyId}
         onEdit={handleEdit}
       />
-      <ExpenseModal
+      <EditExpenseModal
         isOpen={editOpen}
         onClose={() => setEditOpen(false)}
         transaction={editTx}

--- a/budget-tracker-front/src/pages/Incomes/IncomesTable/IncomesTable.js
+++ b/budget-tracker-front/src/pages/Incomes/IncomesTable/IncomesTable.js
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef } from 'react';
 import API_ENDPOINTS from '../../../config/apiConfig';
 import DataTable from '../../../components/DataTable/DataTable';
-import IncomeModal from '../../../components/Modals/IncomeModal/IncomeModal';
+import EditIncomeModal from '../../../components/Modals/EditIncomeModal/EditIncomeModal';
 
 const IncomesTable = ({ month, year }) => {
   const [transactions, setTransactions] = useState([]);
@@ -73,7 +73,7 @@ const IncomesTable = ({ month, year }) => {
         deletingId={busyId}
         onEdit={handleEdit}
       />
-      <IncomeModal
+      <EditIncomeModal
         isOpen={editOpen}
         onClose={() => setEditOpen(false)}
         transaction={editTx}

--- a/budget-tracker-front/src/pages/Transfers/TransfersTable/TransfersTable.js
+++ b/budget-tracker-front/src/pages/Transfers/TransfersTable/TransfersTable.js
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef } from 'react';
 import API_ENDPOINTS from '../../../config/apiConfig';
 import DataTable from '../../../components/DataTable/DataTable';
-import TransferModal from '../../../components/Modals/TransferModal/TransferModal';
+import EditTransferModal from '../../../components/Modals/EditTransferModal/EditTransferModal';
 
 const TransfersTable = ({ month, year }) => {
   const [rows, setRows] = useState([]);
@@ -71,7 +71,7 @@ const TransfersTable = ({ month, year }) => {
         deletingId={busyId}
         onEdit={handleEdit}
       />
-      <TransferModal
+      <EditTransferModal
         isOpen={editOpen}
         onClose={() => setEditOpen(false)}
         transaction={editTx}


### PR DESCRIPTION
## Summary
- add new EditExpenseModal/EditIncomeModal/EditTransferModal components
- wire edit pages to use new edit modals
- keep create modals unchanged

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687e9cad04908330908e039ab0f66f76