### PR TITLE
Add date fields to transaction modals

### DIFF
--- a/budget-tracker-front/src/components/Modals/EditExpenseModal/EditExpenseModal.js
+++ b/budget-tracker-front/src/components/Modals/EditExpenseModal/EditExpenseModal.js
@@ -10,7 +10,7 @@ const EditExpenseModal = ({ isOpen, onClose, transaction, onSaved }) => {
   const [accountFrom, setAccountFrom] = useState("");
   const [budgetPlanId, setBudgetPlanId] = useState("");
   const [description, setDescription] = useState("");
-  const [date, setDate] = useState("");
+  const [date, setDate] = useState(new Date().toISOString().split("T")[0]);
 
   const [currencies, setCurrencies] = useState([]);
   const [categories, setCategories] = useState([]);
@@ -50,7 +50,9 @@ const EditExpenseModal = ({ isOpen, onClose, transaction, onSaved }) => {
       setAccountFrom(transaction.accountFrom ? String(transaction.accountFrom) : "");
       setBudgetPlanId(transaction.budgetPlanId ? String(transaction.budgetPlanId) : "");
       setDescription(transaction.description || "");
-      setDate(transaction.date || "");
+      setDate(
+        transaction.date ? transaction.date.split("T")[0] : new Date().toISOString().split("T")[0]
+      );
     }
     document.addEventListener("keydown", handleEsc);
     return () => document.removeEventListener("keydown", handleEsc);
@@ -63,7 +65,8 @@ const EditExpenseModal = ({ isOpen, onClose, transaction, onSaved }) => {
       !currencyId ||
       !categoryId ||
       !accountFrom ||
-      !budgetPlanId
+      !budgetPlanId ||
+      !date
     ) {
       alert("Please fill in all fields!");
       return;
@@ -77,7 +80,7 @@ const EditExpenseModal = ({ isOpen, onClose, transaction, onSaved }) => {
       budgetPlanId: parseInt(budgetPlanId),
       currencyId: parseInt(currencyId),
       categoryId: parseInt(categoryId),
-      date,
+      date: new Date(date).toISOString(),
       description,
       type: 2,
     };
@@ -157,6 +160,12 @@ const EditExpenseModal = ({ isOpen, onClose, transaction, onSaved }) => {
             </option>
           ))}
         </select>
+
+        <input
+          type="date"
+          value={date}
+          onChange={(e) => setDate(e.target.value)}
+        />
 
         <textarea
           placeholder="Description"

--- a/budget-tracker-front/src/components/Modals/EditIncomeModal/EditIncomeModal.js
+++ b/budget-tracker-front/src/components/Modals/EditIncomeModal/EditIncomeModal.js
@@ -9,7 +9,7 @@ const EditIncomeModal = ({ isOpen, onClose, transaction, onSaved }) => {
   const [categoryId, setCategoryId] = useState("");
   const [accountTo, setAccountTo] = useState("");
   const [description, setDescription] = useState("");
-  const [date, setDate] = useState("");
+  const [date, setDate] = useState(new Date().toISOString().split("T")[0]);
   const [currencies, setCurrencies] = useState([]);
   const [categories, setCategories] = useState([]);
   const [accounts, setAccounts] = useState([]);
@@ -46,7 +46,9 @@ const EditIncomeModal = ({ isOpen, onClose, transaction, onSaved }) => {
       setCategoryId(transaction.categoryId ? String(transaction.categoryId) : "");
       setAccountTo(transaction.accountTo ? String(transaction.accountTo) : "");
       setDescription(transaction.description || "");
-      setDate(transaction.date || "");
+      setDate(
+        transaction.date ? transaction.date.split("T")[0] : new Date().toISOString().split("T")[0]
+      );
     }
 
     document.addEventListener("keydown", handleKeyDown);
@@ -56,7 +58,7 @@ const EditIncomeModal = ({ isOpen, onClose, transaction, onSaved }) => {
   }, [isOpen, onClose, transaction]);
 
   const handleSubmit = async () => {
-    if (!title || !amount || !currencyId || !categoryId || !accountTo) {
+    if (!title || !amount || !currencyId || !categoryId || !accountTo || !date) {
       alert("Please fill in all fields!");
       return;
     }
@@ -70,7 +72,7 @@ const EditIncomeModal = ({ isOpen, onClose, transaction, onSaved }) => {
       amount: parseFloat(amount),
       currencyId: parseInt(currencyId),
       categoryId: parseInt(categoryId),
-      date,
+      date: new Date(date).toISOString(),
       accountTo: parseInt(accountTo),
       description,
       type: 1,
@@ -144,6 +146,12 @@ const EditIncomeModal = ({ isOpen, onClose, transaction, onSaved }) => {
             </option>
           ))}
         </select>
+
+        <input
+          type="date"
+          value={date}
+          onChange={(e) => setDate(e.target.value)}
+        />
 
         <textarea
           placeholder="Description"

--- a/budget-tracker-front/src/components/Modals/EditTransferModal/EditTransferModal.js
+++ b/budget-tracker-front/src/components/Modals/EditTransferModal/EditTransferModal.js
@@ -10,7 +10,7 @@ const EditTransferModal = ({ isOpen, onClose, transaction, onSaved }) => {
   const [accountTo, setAccountTo] = useState("");
   const [description, setDescription] = useState("");
   const [categoryId, setCategoryId] = useState("");
-  const [date, setDate] = useState("");
+  const [date, setDate] = useState(new Date().toISOString().split("T")[0]);
   const [currencies, setCurrencies] = useState([]);
   const [accounts, setAccounts] = useState([]);
   const [categories, setCategories] = useState([]);
@@ -48,7 +48,9 @@ const EditTransferModal = ({ isOpen, onClose, transaction, onSaved }) => {
       setAccountTo(transaction.accountTo ? String(transaction.accountTo) : "");
       setCategoryId(transaction.categoryId ? String(transaction.categoryId) : "");
       setDescription(transaction.description || "");
-      setDate(transaction.date || "");
+      setDate(
+        transaction.date ? transaction.date.split("T")[0] : new Date().toISOString().split("T")[0]
+      );
     }
 
     document.addEventListener("keydown", handleKeyDown);
@@ -58,7 +60,7 @@ const EditTransferModal = ({ isOpen, onClose, transaction, onSaved }) => {
   }, [isOpen, onClose, transaction]);
 
   const handleSubmit = async () => {
-    if (!title || !amount || !currencyId || !accountFrom || !accountTo) {
+    if (!title || !amount || !currencyId || !accountFrom || !accountTo || !date) {
       alert("Please fill in all fields!");
       return;
     }
@@ -78,7 +80,7 @@ const EditTransferModal = ({ isOpen, onClose, transaction, onSaved }) => {
       accountTo: parseInt(accountTo),
       currencyId: parseInt(currencyId),
       categoryId: parseInt(categoryId),
-      date,
+      date: new Date(date).toISOString(),
       description,
       type: 0,
     };
@@ -164,6 +166,12 @@ const EditTransferModal = ({ isOpen, onClose, transaction, onSaved }) => {
             </option>
           ))}
         </select>
+
+        <input
+          type="date"
+          value={date}
+          onChange={(e) => setDate(e.target.value)}
+        />
 
         <textarea
           placeholder="Description"

--- a/budget-tracker-front/src/components/Modals/ExpenseModal/ExpenseModal.js
+++ b/budget-tracker-front/src/components/Modals/ExpenseModal/ExpenseModal.js
@@ -10,7 +10,7 @@ const ExpenseModal = ({ isOpen, onClose, transaction, onSaved }) => {
   const [accountFrom, setAccountFrom] = useState("");
   const [budgetPlanId, setBudgetPlanId] = useState("");
   const [description, setDescription] = useState("");
-  const [date, setDate] = useState("");
+  const [date, setDate] = useState(new Date().toISOString().split("T")[0]);
 
   const [currencies, setCurrencies] = useState([]);
   const [categories, setCategories] = useState([]);
@@ -50,7 +50,9 @@ const ExpenseModal = ({ isOpen, onClose, transaction, onSaved }) => {
       setAccountFrom(transaction.accountFrom ? String(transaction.accountFrom) : "");
       setBudgetPlanId(transaction.budgetPlanId ? String(transaction.budgetPlanId) : "");
       setDescription(transaction.description || "");
-      setDate(transaction.date || "");
+      setDate(
+        transaction.date ? transaction.date.split("T")[0] : new Date().toISOString().split("T")[0]
+      );
     } else {
       setTitle("");
       setAmount("");
@@ -59,7 +61,7 @@ const ExpenseModal = ({ isOpen, onClose, transaction, onSaved }) => {
       setAccountFrom("");
       setBudgetPlanId("");
       setDescription("");
-      setDate("");
+      setDate(new Date().toISOString().split("T")[0]);
     }
     document.addEventListener("keydown", handleEsc);
     return () => document.removeEventListener("keydown", handleEsc);
@@ -72,7 +74,8 @@ const ExpenseModal = ({ isOpen, onClose, transaction, onSaved }) => {
       !currencyId ||
       !categoryId ||
       !accountFrom ||
-      !budgetPlanId
+      !budgetPlanId ||
+      !date
     ) {
       alert("Please fill in all fields!");
       return;
@@ -85,7 +88,7 @@ const ExpenseModal = ({ isOpen, onClose, transaction, onSaved }) => {
       budgetPlanId: parseInt(budgetPlanId),
       currencyId: parseInt(currencyId),
       categoryId: parseInt(categoryId),
-      date: transaction ? date : new Date().toISOString(),
+      date: new Date(date).toISOString(),
       description,
       id: transaction ? transaction.id : undefined,
     };
@@ -180,6 +183,12 @@ const ExpenseModal = ({ isOpen, onClose, transaction, onSaved }) => {
             </option>
           ))}
         </select>
+
+        <input
+          type="date"
+          value={date}
+          onChange={(e) => setDate(e.target.value)}
+        />
 
         <textarea
           placeholder="Опис"

--- a/budget-tracker-front/src/components/Modals/IncomeModal/IncomeModal.js
+++ b/budget-tracker-front/src/components/Modals/IncomeModal/IncomeModal.js
@@ -9,7 +9,7 @@ const IncomeModal = ({ isOpen, onClose, transaction, onSaved }) => {
   const [categoryId, setCategoryId] = useState("");
   const [accountTo, setAccountTo] = useState("");
   const [description, setDescription] = useState("");
-  const [date, setDate] = useState("");
+  const [date, setDate] = useState(new Date().toISOString().split("T")[0]);
   const [currencies, setCurrencies] = useState([]);
   const [categories, setCategories] = useState([]);
   const [accounts, setAccounts] = useState([]);
@@ -46,7 +46,9 @@ const IncomeModal = ({ isOpen, onClose, transaction, onSaved }) => {
       setCategoryId(transaction.categoryId ? String(transaction.categoryId) : "");
       setAccountTo(transaction.accountTo ? String(transaction.accountTo) : "");
       setDescription(transaction.description || "");
-      setDate(transaction.date || "");
+      setDate(
+        transaction.date ? transaction.date.split("T")[0] : new Date().toISOString().split("T")[0]
+      );
     } else {
       setTitle("");
       setAmount("");
@@ -54,7 +56,7 @@ const IncomeModal = ({ isOpen, onClose, transaction, onSaved }) => {
       setCategoryId("");
       setAccountTo("");
       setDescription("");
-      setDate("");
+      setDate(new Date().toISOString().split("T")[0]);
     }
 
     document.addEventListener("keydown", handleKeyDown);
@@ -66,7 +68,7 @@ const IncomeModal = ({ isOpen, onClose, transaction, onSaved }) => {
   }, [isOpen, onClose, transaction]);
 
   const handleSubmit = async () => {
-    if (!title || !amount || !currencyId || !categoryId || !accountTo) {
+    if (!title || !amount || !currencyId || !categoryId || !accountTo || !date) {
       alert("Please fill in all fields!");
       return;
     }
@@ -79,7 +81,7 @@ const IncomeModal = ({ isOpen, onClose, transaction, onSaved }) => {
       amount: parseFloat(amount),
       currencyId: parseInt(currencyId),
       categoryId: parseInt(categoryId),
-      date: transaction ? date : new Date().toISOString(),
+      date: new Date(date).toISOString(),
       accountTo: parseInt(accountTo),
       description,
       id: transaction ? transaction.id : undefined,
@@ -165,6 +167,12 @@ const IncomeModal = ({ isOpen, onClose, transaction, onSaved }) => {
             </option>
           ))}
         </select>
+
+        <input
+          type="date"
+          value={date}
+          onChange={(e) => setDate(e.target.value)}
+        />
 
         <textarea
           placeholder="Опис"

--- a/budget-tracker-front/src/components/Modals/TransferModal/TransferModal.js
+++ b/budget-tracker-front/src/components/Modals/TransferModal/TransferModal.js
@@ -10,7 +10,7 @@ const TransferModal = ({ isOpen, onClose, transaction, onSaved }) => {
   const [accountTo, setAccountTo] = useState("");
   const [description, setDescription] = useState("");
   const [categoryId, setCategoryId] = useState("");
-  const [date, setDate] = useState("");
+  const [date, setDate] = useState(new Date().toISOString().split("T")[0]);
   const [currencies, setCurrencies] = useState([]);
   const [accounts, setAccounts] = useState([]);
   const [categories, setCategories] = useState([]);
@@ -48,7 +48,9 @@ const TransferModal = ({ isOpen, onClose, transaction, onSaved }) => {
       setAccountTo(transaction.accountTo ? String(transaction.accountTo) : "");
       setCategoryId(transaction.categoryId ? String(transaction.categoryId) : "");
       setDescription(transaction.description || "");
-      setDate(transaction.date || "");
+      setDate(
+        transaction.date ? transaction.date.split("T")[0] : new Date().toISOString().split("T")[0]
+      );
     } else {
       setTitle("");
       setAmount("");
@@ -57,7 +59,7 @@ const TransferModal = ({ isOpen, onClose, transaction, onSaved }) => {
       setAccountTo("");
       setCategoryId("");
       setDescription("");
-      setDate("");
+      setDate(new Date().toISOString().split("T")[0]);
     }
 
     document.addEventListener("keydown", handleKeyDown);
@@ -68,7 +70,7 @@ const TransferModal = ({ isOpen, onClose, transaction, onSaved }) => {
   }, [isOpen, onClose, transaction]);
 
   const handleSubmit = async () => {
-    if (!title || !amount || !currencyId || !accountFrom || !accountTo) {
+    if (!title || !amount || !currencyId || !accountFrom || !accountTo || !date) {
       alert("Please fill in all fields!");
       return;
     }
@@ -87,7 +89,7 @@ const TransferModal = ({ isOpen, onClose, transaction, onSaved }) => {
       accountTo: parseInt(accountTo),
       currencyId: parseInt(currencyId),
       categoryId: parseInt(categoryId),
-      date: transaction ? date : new Date().toISOString(),
+      date: new Date(date).toISOString(),
       description,
       id: transaction ? transaction.id : undefined,
     };
@@ -190,6 +192,12 @@ const TransferModal = ({ isOpen, onClose, transaction, onSaved }) => {
             </option>
           ))}
         </select>
+
+        <input
+          type="date"
+          value={date}
+          onChange={(e) => setDate(e.target.value)}
+        />
 
         <textarea
           placeholder="Опис"


### PR DESCRIPTION
## Summary
- allow users to specify a transaction date when creating or editing
- default new transactions to today's date
- keep existing transaction date when editing

## Testing
- `npm test --silent -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6888e95d022483309d375faecd331f66