### PR TITLE
Add user authentication flow with token support

### DIFF
--- a/budget-tracker-front/src/App.js
+++ b/budget-tracker-front/src/App.js
@@ -1,37 +1,32 @@
 import React from "react";
-import Sidebar from "./components/Sidebar/Sidebar";
-import Header from "./components/Header/Header";
 import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
 import Dashboard from "./pages/Dashboard";
 import Expenses from "./pages/Expenses";
 import Incomes from "./pages/Incomes";
 import BudgetPlanPage from "./pages/BudgetPlan";
-import styles from "./App.module.css";
 import TransfersPage from "./pages/Transfers";
 import SettingsPage from "./pages/Settings";
 import MonthlyReport from "./pages/MonthlyReport";
+import { LoginPage, RegisterPage } from "./pages/Auth";
+import ProtectedLayout from "./components/ProtectedLayout/ProtectedLayout";
 
 const App = () => {
   return (
     <Router>
-      <div className={styles.app}>
-        <Header />
-        <div className={styles["main-content"]}>
-          <Sidebar />
-          <main className={styles.content}>
-            <Routes>
-              <Route path="/" element={<Dashboard />} />
-              <Route path="/dashboard" element={<Dashboard />} />
-              <Route path="/expenses" element={<Expenses />} />
-              <Route path="/incomes" element={<Incomes />} />
-              <Route path="/budget-plans" element={<BudgetPlanPage />} />
-              <Route path="/transfers" element={<TransfersPage />} />
-              <Route path="/settings" element={<SettingsPage />} />
-              <Route path="/report" element={<MonthlyReport />} />
-            </Routes>
-          </main>
-        </div>
-      </div>
+      <Routes>
+        <Route path="/login" element={<LoginPage />} />
+        <Route path="/register" element={<RegisterPage />} />
+        <Route element={<ProtectedLayout />}>
+          <Route path="/" element={<Dashboard />} />
+          <Route path="/dashboard" element={<Dashboard />} />
+          <Route path="/expenses" element={<Expenses />} />
+          <Route path="/incomes" element={<Incomes />} />
+          <Route path="/budget-plans" element={<BudgetPlanPage />} />
+          <Route path="/transfers" element={<TransfersPage />} />
+          <Route path="/settings" element={<SettingsPage />} />
+          <Route path="/report" element={<MonthlyReport />} />
+        </Route>
+      </Routes>
     </Router>
   );
 };

--- a/budget-tracker-front/src/components/Header/Header.js
+++ b/budget-tracker-front/src/components/Header/Header.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import styles from "./Header.module.css";
 
@@ -8,15 +8,19 @@ import IncomeModal from "../Modals/IncomeModal/IncomeModal";
 import TransferModal from "../Modals/TransferModal/TransferModal";
 import API_ENDPOINTS from "../../config/apiConfig";
 import { pageTitles } from "../../config/constants";
+import { useAuth } from "../../context/AuthContext";
 
 const Header = () => {
   const location = useLocation();
   const navigate = useNavigate();
+  const { logout } = useAuth();
   const currentPageTitle = pageTitles[location.pathname] || "My App";
 
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isIncomeModalOpen, setIsIncomeModalOpen] = useState(false);
   const [isTransferModalOpen, setIsTransferModalOpen] = useState(false);
+  const [isUserMenuOpen, setIsUserMenuOpen] = useState(false);
+  const avatarRef = useRef(null);
 
   /* — планы — */
   const [plans, setPlans] = useState([]);
@@ -40,6 +44,21 @@ const Header = () => {
     setSelectedPlanId(e.target.value);
     navigate(`/budget-plans?planId=${e.target.value}`);
   };
+
+  const handleLogout = async () => {
+    await logout();
+    navigate("/login");
+  };
+
+  useEffect(() => {
+    const handleClickOutside = (e) => {
+      if (avatarRef.current && !avatarRef.current.contains(e.target)) {
+        setIsUserMenuOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
 
   return (
     <header className={styles.header}>
@@ -103,8 +122,18 @@ const Header = () => {
             className={styles["bell-icon"]}
           />
         </div>
-        <div className={styles["header-right-avatar"]}>
-          <img src="favicon.ico" alt="User Avatar" className={styles.avatar} />
+        <div className={styles["header-right-avatar"]} ref={avatarRef}>
+          <button
+            className={styles["avatar-button"]}
+            onClick={() => setIsUserMenuOpen((o) => !o)}
+          >
+            <img src="favicon.ico" alt="User Avatar" className={styles.avatar} />
+          </button>
+          {isUserMenuOpen && (
+            <div className={styles["user-menu"]}>
+              <button onClick={handleLogout}>Logout</button>
+            </div>
+          )}
         </div>
       </div>
 

--- a/budget-tracker-front/src/components/Header/Header.module.css
+++ b/budget-tracker-front/src/components/Header/Header.module.css
@@ -77,13 +77,49 @@
 }
 
 .header-right-avatar {
+  position: relative;
   height: 100%;
   display: flex;
   align-items: center;
 
+  .avatar-button {
+    background: none;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+  }
+
   .avatar {
     height: 40px;
     border-radius: 50%;
+  }
+
+  .user-menu {
+    position: absolute;
+    right: 0;
+    top: calc(100% + 8px);
+    background: var(--background-color);
+    border: 1px solid var(--table-row-hover-bg);
+    border-radius: 8px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    min-width: 140px;
+    z-index: 10;
+
+    button {
+      background: none;
+      border: none;
+      padding: 10px 15px;
+      color: var(--color-light);
+      text-align: left;
+      cursor: pointer;
+    }
+
+    button:hover {
+      background: var(--table-row-hover-bg);
+    }
   }
 }
 

--- a/budget-tracker-front/src/components/ProtectedLayout/ProtectedLayout.js
+++ b/budget-tracker-front/src/components/ProtectedLayout/ProtectedLayout.js
@@ -5,7 +5,8 @@ import styles from "../../App.module.css";
 import { useAuth } from "../../context/AuthContext";
 
 const ProtectedLayout = () => {
-  const { isAuthenticated } = useAuth();
+  const { isAuthenticated, initializing } = useAuth();
+  if (initializing) return null;
   if (!isAuthenticated) {
     return <Navigate to="/login" replace />;
   }

--- a/budget-tracker-front/src/components/ProtectedLayout/ProtectedLayout.js
+++ b/budget-tracker-front/src/components/ProtectedLayout/ProtectedLayout.js
@@ -1,0 +1,25 @@
+import { Outlet, Navigate } from "react-router-dom";
+import Sidebar from "../Sidebar/Sidebar";
+import Header from "../Header/Header";
+import styles from "../../App.module.css";
+import { useAuth } from "../../context/AuthContext";
+
+const ProtectedLayout = () => {
+  const { isAuthenticated } = useAuth();
+  if (!isAuthenticated) {
+    return <Navigate to="/login" replace />;
+  }
+  return (
+    <div className={styles.app}>
+      <Header />
+      <div className={styles["main-content"]}>
+        <Sidebar />
+        <main className={styles.content}>
+          <Outlet />
+        </main>
+      </div>
+    </div>
+  );
+};
+
+export default ProtectedLayout;

--- a/budget-tracker-front/src/components/Sidebar/Sidebar.js
+++ b/budget-tracker-front/src/components/Sidebar/Sidebar.js
@@ -1,17 +1,9 @@
-import { Link, useNavigate } from "react-router-dom";
+import { Link } from "react-router-dom";
 import styles from "./Sidebar.module.css";
 import starIcon from "../../data/Star.svg";
 import { menuLinks } from "../../config/constants";
-import { useAuth } from "../../context/AuthContext";
 
 const Sidebar = () => {
-  const { logout } = useAuth();
-  const navigate = useNavigate();
-
-  const handleLogout = async () => {
-    await logout();
-    navigate("/login");
-  };
 
   return (
     <div className={styles.sidebar}>
@@ -28,9 +20,6 @@ const Sidebar = () => {
           <img src={starIcon} alt="icon" className={styles["sidebar-icon"]} />
           Settings
         </Link>
-        <button onClick={handleLogout} className={styles["sidebar-item"]}>
-          Logout
-        </button>
       </div>
     </div>
   );

--- a/budget-tracker-front/src/components/Sidebar/Sidebar.js
+++ b/budget-tracker-front/src/components/Sidebar/Sidebar.js
@@ -1,25 +1,39 @@
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import styles from "./Sidebar.module.css";
 import starIcon from "../../data/Star.svg";
 import { menuLinks } from "../../config/constants";
+import { useAuth } from "../../context/AuthContext";
 
-const Sidebar = () => (
-  <div className={styles.sidebar}>
-    <nav className={styles["sidebar-menu"]}>
-      {menuLinks.map(({ to, label, icon }) => (
-        <Link key={to} to={to} className={styles["sidebar-item"]}>
-          <img src={icon} alt="icon" className={styles["sidebar-icon"]} />
-          {label}
+const Sidebar = () => {
+  const { logout } = useAuth();
+  const navigate = useNavigate();
+
+  const handleLogout = async () => {
+    await logout();
+    navigate("/login");
+  };
+
+  return (
+    <div className={styles.sidebar}>
+      <nav className={styles["sidebar-menu"]}>
+        {menuLinks.map(({ to, label, icon }) => (
+          <Link key={to} to={to} className={styles["sidebar-item"]}>
+            <img src={icon} alt="icon" className={styles["sidebar-icon"]} />
+            {label}
+          </Link>
+        ))}
+      </nav>
+      <div className={styles["sidebar-settings"]}>
+        <Link to="/settings" className={styles["sidebar-item"]}>
+          <img src={starIcon} alt="icon" className={styles["sidebar-icon"]} />
+          Settings
         </Link>
-      ))}
-    </nav>
-    <div className={styles["sidebar-settings"]}>
-      <Link to="/settings" className={styles["sidebar-item"]}>
-        <img src={starIcon} alt="icon" className={styles["sidebar-icon"]} />
-        Settings
-      </Link>
+        <button onClick={handleLogout} className={styles["sidebar-item"]}>
+          Logout
+        </button>
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 export default Sidebar;

--- a/budget-tracker-front/src/config/apiConfig.js
+++ b/budget-tracker-front/src/config/apiConfig.js
@@ -1,8 +1,19 @@
 // src/config/apiConfig.js
 
-const API_BASE_URL = "https://localhost:7281/api";
+// base backend url
+export const BASE_URL = "https://localhost:7281";
+
+const API_BASE_URL = `${BASE_URL}/api`;
+const AUTH_BASE_URL = `${BASE_URL}/auth`;
 
 export const API_ENDPOINTS = {
+  // Auth
+  auth: {
+    register: `${AUTH_BASE_URL}/register`,
+    login: `${AUTH_BASE_URL}/login`,
+    logout: `${AUTH_BASE_URL}/logout`,
+    refresh: `${AUTH_BASE_URL}/refresh`,
+  },
   // Accounts
   accounts: `${API_BASE_URL}/Accounts`,
   createAccount: `${API_BASE_URL}/Accounts`,

--- a/budget-tracker-front/src/context/AuthContext.js
+++ b/budget-tracker-front/src/context/AuthContext.js
@@ -1,0 +1,125 @@
+import { createContext, useContext, useState, useEffect } from "react";
+import API_ENDPOINTS, { BASE_URL } from "../config/apiConfig";
+
+const AuthContext = createContext(null);
+
+export const AuthProvider = ({ children }) => {
+  const [accessToken, setAccessToken] = useState(
+    () => localStorage.getItem("accessToken")
+  );
+  const [refreshToken, setRefreshToken] = useState(
+    () => localStorage.getItem("refreshToken")
+  );
+
+  const saveTokens = ({ accessToken, refreshToken }) => {
+    setAccessToken(accessToken);
+    setRefreshToken(refreshToken);
+    localStorage.setItem("accessToken", accessToken);
+    localStorage.setItem("refreshToken", refreshToken);
+  };
+
+  const register = async (email, password) => {
+    const res = await fetch(API_ENDPOINTS.auth.register, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email, password }),
+    });
+    if (!res.ok) throw new Error("Registration failed");
+    const data = await res.json();
+    saveTokens(data);
+  };
+
+  const login = async (email, password) => {
+    const res = await fetch(API_ENDPOINTS.auth.login, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email, password }),
+    });
+    if (!res.ok) throw new Error("Login failed");
+    const data = await res.json();
+    saveTokens(data);
+  };
+
+  const logout = async () => {
+    if (accessToken && refreshToken) {
+      await fetch(API_ENDPOINTS.auth.logout, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${accessToken}`,
+        },
+        body: JSON.stringify({ accessToken, refreshToken }),
+      }).catch(() => {});
+    }
+    setAccessToken(null);
+    setRefreshToken(null);
+    localStorage.removeItem("accessToken");
+    localStorage.removeItem("refreshToken");
+  };
+
+  const refresh = async () => {
+    if (!accessToken || !refreshToken) return null;
+    const res = await fetch(API_ENDPOINTS.auth.refresh, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${accessToken}`,
+      },
+      body: JSON.stringify({ accessToken, refreshToken }),
+    });
+    if (res.ok) {
+      const data = await res.json();
+      saveTokens(data);
+      return data.accessToken;
+    } else {
+      await logout();
+      return null;
+    }
+  };
+
+  useEffect(() => {
+    const originalFetch = window.fetch;
+    window.fetch = async (input, init = {}) => {
+      const url = typeof input === "string" ? input : input.url;
+      const options = { ...init };
+      if (accessToken && url.startsWith(BASE_URL)) {
+        options.headers = {
+          ...(options.headers || {}),
+          Authorization: `Bearer ${accessToken}`,
+        };
+      }
+      let response = await originalFetch(input, options);
+      if (response.status === 401 && refreshToken) {
+        const newToken = await refresh();
+        if (newToken) {
+          options.headers = {
+            ...(options.headers || {}),
+            Authorization: `Bearer ${newToken}`,
+          };
+          response = await originalFetch(input, options);
+        }
+      }
+      return response;
+    };
+    return () => {
+      window.fetch = originalFetch;
+    };
+  }, [accessToken, refreshToken]);
+
+  const value = {
+    accessToken,
+    refreshToken,
+    isAuthenticated: !!accessToken,
+    register,
+    login,
+    logout,
+  };
+
+  return (
+    <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
+  );
+};
+
+export const useAuth = () => useContext(AuthContext);
+
+export default AuthContext;

--- a/budget-tracker-front/src/index.js
+++ b/budget-tracker-front/src/index.js
@@ -2,11 +2,14 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import "./index.css";
 import App from "./App";
+import { AuthProvider } from "./context/AuthContext";
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(
   <React.StrictMode>
-    <App />
+    <AuthProvider>
+      <App />
+    </AuthProvider>
   </React.StrictMode>
 );
 

--- a/budget-tracker-front/src/pages/Auth/AuthPage.module.css
+++ b/budget-tracker-front/src/pages/Auth/AuthPage.module.css
@@ -1,0 +1,70 @@
+.auth-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  background-color: var(--background-color);
+}
+
+.auth-card {
+  background-color: var(--color-gray-dark);
+  padding: 2rem;
+  border-radius: var(--border-radius-medium);
+  box-shadow: var(--shadow-medium);
+  width: 100%;
+  max-width: 400px;
+  color: var(--text-color);
+}
+
+.auth-title {
+  text-align: center;
+  margin-bottom: 1rem;
+}
+
+.auth-form {
+  display: flex;
+  flex-direction: column;
+}
+
+.auth-input {
+  margin-bottom: var(--spacing-medium);
+  padding: var(--spacing-small);
+  border-radius: var(--border-radius-small);
+  border: 1px solid var(--color-gray-medium);
+  background: var(--color-dark);
+  color: var(--text-color);
+}
+
+.auth-button {
+  padding: var(--spacing-small);
+  background: var(--color-purple-dark);
+  color: var(--color-light);
+  border: none;
+  border-radius: var(--border-radius-small);
+  cursor: pointer;
+  transition: background-color 0.3s ease;
+}
+
+.auth-button:hover {
+  background: var(--color-gray-medium);
+}
+
+.auth-error {
+  color: var(--error-color);
+  text-align: center;
+  margin-bottom: var(--spacing-medium);
+}
+
+.auth-link {
+  margin-top: var(--spacing-medium);
+  text-align: center;
+}
+
+.auth-card a {
+  color: var(--primary-color);
+  text-decoration: none;
+}
+
+.auth-card a:hover {
+  text-decoration: underline;
+}

--- a/budget-tracker-front/src/pages/Auth/LoginPage.js
+++ b/budget-tracker-front/src/pages/Auth/LoginPage.js
@@ -1,0 +1,48 @@
+import { useState } from "react";
+import { useNavigate, Link } from "react-router-dom";
+import { useAuth } from "../../context/AuthContext";
+
+const LoginPage = () => {
+  const { login } = useAuth();
+  const navigate = useNavigate();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState(null);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      await login(email, password);
+      navigate("/");
+    } catch {
+      setError("Login failed");
+    }
+  };
+
+  return (
+    <div>
+      <h2>Login</h2>
+      <form onSubmit={handleSubmit}>
+        <input
+          type="text"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        <button type="submit">Login</button>
+      </form>
+      {error && <p>{error}</p>}
+      <p>
+        Don't have an account? <Link to="/register">Register</Link>
+      </p>
+    </div>
+  );
+};
+
+export default LoginPage;

--- a/budget-tracker-front/src/pages/Auth/LoginPage.js
+++ b/budget-tracker-front/src/pages/Auth/LoginPage.js
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useNavigate, Link } from "react-router-dom";
 import { useAuth } from "../../context/AuthContext";
+import styles from "./AuthPage.module.css";
 
 const LoginPage = () => {
   const { login } = useAuth();
@@ -13,34 +14,40 @@ const LoginPage = () => {
     e.preventDefault();
     try {
       await login(email, password);
-      navigate("/");
+      navigate("/dashboard");
     } catch {
       setError("Login failed");
     }
   };
 
   return (
-    <div>
-      <h2>Login</h2>
-      <form onSubmit={handleSubmit}>
-        <input
-          type="text"
-          placeholder="Email"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-        />
-        <input
-          type="password"
-          placeholder="Password"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-        />
-        <button type="submit">Login</button>
-      </form>
-      {error && <p>{error}</p>}
-      <p>
-        Don't have an account? <Link to="/register">Register</Link>
-      </p>
+    <div className={styles["auth-container"]}>
+      <div className={styles["auth-card"]}>
+        <h2 className={styles["auth-title"]}>Login</h2>
+        <form onSubmit={handleSubmit} className={styles["auth-form"]}>
+          <input
+            className={styles["auth-input"]}
+            type="text"
+            placeholder="Email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+          />
+          <input
+            className={styles["auth-input"]}
+            type="password"
+            placeholder="Password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+          <button type="submit" className={styles["auth-button"]}>
+            Login
+          </button>
+        </form>
+        {error && <p className={styles["auth-error"]}>{error}</p>}
+        <p className={styles["auth-link"]}>
+          Don't have an account? <Link to="/register">Register</Link>
+        </p>
+      </div>
     </div>
   );
 };

--- a/budget-tracker-front/src/pages/Auth/RegisterPage.js
+++ b/budget-tracker-front/src/pages/Auth/RegisterPage.js
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useNavigate, Link } from "react-router-dom";
 import { useAuth } from "../../context/AuthContext";
+import styles from "./AuthPage.module.css";
 
 const RegisterPage = () => {
   const { register } = useAuth();
@@ -13,34 +14,40 @@ const RegisterPage = () => {
     e.preventDefault();
     try {
       await register(email, password);
-      navigate("/");
+      navigate("/dashboard");
     } catch {
       setError("Registration failed");
     }
   };
 
   return (
-    <div>
-      <h2>Register</h2>
-      <form onSubmit={handleSubmit}>
-        <input
-          type="text"
-          placeholder="Email"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-        />
-        <input
-          type="password"
-          placeholder="Password"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-        />
-        <button type="submit">Register</button>
-      </form>
-      {error && <p>{error}</p>}
-      <p>
-        Already have an account? <Link to="/login">Login</Link>
-      </p>
+    <div className={styles["auth-container"]}>
+      <div className={styles["auth-card"]}> 
+        <h2 className={styles["auth-title"]}>Register</h2>
+        <form onSubmit={handleSubmit} className={styles["auth-form"]}>
+          <input
+            className={styles["auth-input"]}
+            type="text"
+            placeholder="Email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+          />
+          <input
+            className={styles["auth-input"]}
+            type="password"
+            placeholder="Password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+          <button type="submit" className={styles["auth-button"]}>
+            Register
+          </button>
+        </form>
+        {error && <p className={styles["auth-error"]}>{error}</p>}
+        <p className={styles["auth-link"]}>
+          Already have an account? <Link to="/login">Login</Link>
+        </p>
+      </div>
     </div>
   );
 };

--- a/budget-tracker-front/src/pages/Auth/RegisterPage.js
+++ b/budget-tracker-front/src/pages/Auth/RegisterPage.js
@@ -1,0 +1,48 @@
+import { useState } from "react";
+import { useNavigate, Link } from "react-router-dom";
+import { useAuth } from "../../context/AuthContext";
+
+const RegisterPage = () => {
+  const { register } = useAuth();
+  const navigate = useNavigate();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState(null);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      await register(email, password);
+      navigate("/");
+    } catch {
+      setError("Registration failed");
+    }
+  };
+
+  return (
+    <div>
+      <h2>Register</h2>
+      <form onSubmit={handleSubmit}>
+        <input
+          type="text"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        <button type="submit">Register</button>
+      </form>
+      {error && <p>{error}</p>}
+      <p>
+        Already have an account? <Link to="/login">Login</Link>
+      </p>
+    </div>
+  );
+};
+
+export default RegisterPage;

--- a/budget-tracker-front/src/pages/Auth/index.js
+++ b/budget-tracker-front/src/pages/Auth/index.js
@@ -1,0 +1,2 @@
+export { default as LoginPage } from "./LoginPage";
+export { default as RegisterPage } from "./RegisterPage";


### PR DESCRIPTION
## Summary
- add auth endpoints and base url configuration
- implement AuthContext to handle login, register, logout and token refresh
- create protected layout and login/register pages
- send auth token on requests and allow logging out

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68acba63ad9c833083b2a2b74402a09f